### PR TITLE
refactor: add axios services and route guards

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+# Copy this file to .env.local and adjust values
+NEXT_PUBLIC_API_BASE=http://localhost:3200/api/v1

--- a/src/app/general/layout.tsx
+++ b/src/app/general/layout.tsx
@@ -2,7 +2,10 @@
 "use client";
 
 import { GeneralHeader } from "@/components/general-header";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { AuthGuard } from "@/components/auth-guard";
+import { getMe } from "@/services/userService";
 
 export default function GeneralLayout({
   children,
@@ -10,20 +13,37 @@ export default function GeneralLayout({
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
+  const router = useRouter();
+
+  useEffect(() => {
+    getMe()
+      .then((user) => {
+        const roles: string[] = user?.roles ??
+          user?.rol_usuario?.map((r: any) => r?.rol?.nombre) ?? [];
+        if (roles.includes('ADMIN')) {
+          router.replace('/admin/asignaciones');
+        } else if (roles.includes('SUPERVISOR')) {
+          router.replace('/admin/supervision');
+        }
+      })
+      .catch(() => router.replace('/'));
+  }, [router]);
 
   // The document detail page will handle its own header
   const isDocumentDetailPage = pathname.startsWith('/documento/');
 
   if (isDocumentDetailPage) {
-    return <>{children}</>;
+    return <AuthGuard>{children}</AuthGuard>;
   }
 
   return (
-    <div className="flex flex-col h-screen">
-      <GeneralHeader />
-      <main className="flex-1 p-4 md:p-6 overflow-auto">
-        {children}
-      </main>
-    </div>
+    <AuthGuard>
+      <div className="flex flex-col h-screen">
+        <GeneralHeader />
+        <main className="flex-1 p-4 md:p-6 overflow-auto">
+          {children}
+        </main>
+      </div>
+    </AuthGuard>
   );
 }

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { getMe } from '@/services/userService';
+
+interface AuthGuardProps {
+  children: React.ReactNode;
+  roles?: string[];
+}
+
+export function AuthGuard({ children, roles }: AuthGuardProps) {
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    getMe()
+      .then((user) => {
+        const userRoles: string[] = user?.roles ??
+          user?.rol_usuario?.map((r: any) => r?.rol?.nombre) ?? [];
+        if (!roles || roles.some((r) => userRoles.includes(r))) {
+          if (mounted) setAuthorized(true);
+        } else {
+          router.replace('/');
+        }
+      })
+      .catch(() => router.replace('/'));
+    return () => { mounted = false; };
+  }, [router, roles]);
+
+  if (!authorized) return null;
+
+  return <>{children}</>;
+}

--- a/src/lib/axiosConfig.ts
+++ b/src/lib/axiosConfig.ts
@@ -1,0 +1,76 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import { getToken, setToken, clearToken } from './tokenStore';
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_BASE,
+  withCredentials: true,
+});
+
+api.interceptors.request.use((config) => {
+  const token = getToken();
+  if (token && config.headers) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+let isRefreshing = false;
+let failedQueue: {
+  resolve: (value?: unknown) => void;
+  reject: (error: any) => void;
+  config: AxiosRequestConfig;
+}[] = [];
+
+const processQueue = (error: any, token: string | null = null) => {
+  failedQueue.forEach((prom) => {
+    if (error) {
+      prom.reject(error);
+    } else {
+      if (token && prom.config.headers) {
+        prom.config.headers.Authorization = `Bearer ${token}`;
+      }
+      prom.resolve(api(prom.config));
+    }
+  });
+  failedQueue = [];
+};
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalConfig = error.config as AxiosRequestConfig & { _retry?: boolean };
+
+    if (error.response?.status === 401 && !originalConfig._retry) {
+      originalConfig._retry = true;
+
+      if (isRefreshing) {
+        return new Promise((resolve, reject) => {
+          failedQueue.push({ resolve, reject, config: originalConfig });
+        });
+      }
+
+      isRefreshing = true;
+
+      try {
+        const res = await api.post('/auth/refresh');
+        const newToken = (res.data as any)?.access_token;
+        setToken(newToken);
+        processQueue(null, newToken);
+        if (originalConfig.headers) {
+          originalConfig.headers.Authorization = `Bearer ${newToken}`;
+        }
+        return api(originalConfig);
+      } catch (refreshError) {
+        clearToken();
+        processQueue(refreshError, null);
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/src/lib/tokenStore.ts
+++ b/src/lib/tokenStore.ts
@@ -1,0 +1,13 @@
+let accessToken: string | null = null;
+
+export function setToken(token: string | null) {
+  accessToken = token;
+}
+
+export function getToken(): string | null {
+  return accessToken;
+}
+
+export function clearToken() {
+  accessToken = null;
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,18 @@
+import api from '@/lib/axiosConfig';
+import { setToken, clearToken } from '@/lib/tokenStore';
+
+export async function login(email: string, password: string) {
+  const res = await api.post('/auth/login', { user: email, password });
+  const access = res.data?.access_token;
+  if (access) setToken(access);
+  return res.data;
+}
+
+export async function logout() {
+  clearToken();
+  try {
+    await api.post('/auth/logout');
+  } catch (e) {
+    // ignore
+  }
+}

--- a/src/services/documentService.ts
+++ b/src/services/documentService.ts
@@ -1,0 +1,8 @@
+import api from '@/lib/axiosConfig';
+
+export async function signDocument(formData: FormData) {
+  const res = await api.post('/documents/sign', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+  return res.data;
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -1,0 +1,11 @@
+import api from '@/lib/axiosConfig';
+
+export interface User {
+  roles?: string[];
+  [key: string]: any;
+}
+
+export async function getMe(): Promise<User> {
+  const res = await api.get('/users/me');
+  return res.data;
+}


### PR DESCRIPTION
## Summary
- add axios config with token refresh interceptors
- centralize auth, user and document services
- enforce auth guards and role-based redirects

## Testing
- `npm run lint` *(fails: asks for ESLint configuration)*
- `npm run typecheck` *(fails: TypeScript errors in user-form-modal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68bca8ab39d4833285a830a5cc99c444