### PR TITLE
Add API proxies and session management

### DIFF
--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
+
+async function proxy(req: NextRequest, target: string) {
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    credentials: 'include',
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+  const resp = await fetch(target, init);
+  const respHeaders = new Headers(resp.headers);
+  const data = await resp.arrayBuffer();
+  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+}
+
+export async function POST(req: NextRequest) {
+  return proxy(req, `${API_BASE}/auth/refresh`);
+}

--- a/src/app/api/paginas/route.ts
+++ b/src/app/api/paginas/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
+
+async function proxy(req: NextRequest, target: string) {
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    credentials: 'include',
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+  const resp = await fetch(target, init);
+  const respHeaders = new Headers(resp.headers);
+  const data = await resp.arrayBuffer();
+  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req, `${API_BASE}/paginas`);
+}

--- a/src/app/api/roles/[id]/paginas/route.ts
+++ b/src/app/api/roles/[id]/paginas/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
+
+async function proxy(req: NextRequest, target: string) {
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    credentials: 'include',
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+  const resp = await fetch(target, init);
+  const respHeaders = new Headers(resp.headers);
+  const data = await resp.arrayBuffer();
+  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+}
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  return proxy(req, `${API_BASE}/roles/${params.id}/paginas`);
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
+  return proxy(req, `${API_BASE}/roles/${params.id}/paginas`);
+}

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
+
+async function proxy(req: NextRequest, target: string) {
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    credentials: 'include',
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+  const resp = await fetch(target, init);
+  const respHeaders = new Headers(resp.headers);
+  const data = await resp.arrayBuffer();
+  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req, `${API_BASE}/roles`);
+}
+
+export async function POST(req: NextRequest) {
+  return proxy(req, `${API_BASE}/roles`);
+}

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
+
+async function proxy(req: NextRequest, target: string) {
+  const headers = new Headers(req.headers);
+  headers.delete('host');
+  headers.delete('content-length');
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    credentials: 'include',
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+  const resp = await fetch(target, init);
+  const respHeaders = new Headers(resp.headers);
+  const data = await resp.arrayBuffer();
+  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req, `${API_BASE}/users/me`);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type {Metadata} from 'next';
 import './globals.css';
 import { Toaster } from "@/components/ui/toaster"
+import { SessionProvider } from '@/lib/session';
 
 export const metadata: Metadata = {
   title: 'Génesis Sign',
@@ -20,11 +21,13 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Code+Pro:wght@400;500&display=swap" rel="stylesheet" />
       </head>
       <body className="font-body antialiased min-h-screen flex flex-col">
-        <main className="flex-grow">{children}</main>
-        <footer className="py-4 px-6 text-center text-muted-foreground text-sm">
-          <div className="copyright">©2025 Génesis Sign • by MAC Génesis • <span id="blockchain-status">⛓️</span></div>
-        </footer>
-        <Toaster />
+        <SessionProvider>
+          <main className="flex-grow">{children}</main>
+          <footer className="py-4 px-6 text-center text-muted-foreground text-sm">
+            <div className="copyright">©2025 Génesis Sign • by MAC Génesis • <span id="blockchain-status">⛓️</span></div>
+          </footer>
+          <Toaster />
+        </SessionProvider>
       </body>
     </html>
   );

--- a/src/components/RequirePage.tsx
+++ b/src/components/RequirePage.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import React, { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession } from '@/lib/session';
+
+interface Props {
+  url: string;
+  children: React.ReactNode;
+}
+
+export function RequirePage({ url, children }: Props) {
+  const { me, loading } = useSession();
+  const router = useRouter();
+
+  const allowed = me?.pages?.some((p) => p.url === url);
+
+  useEffect(() => {
+    if (!loading && !allowed) {
+      router.replace('/403');
+    }
+  }, [loading, allowed, router]);
+
+  if (loading || !allowed) return null;
+
+  return <>{children}</>;
+}
+
+export default RequirePage;

--- a/src/lib/axiosConfig.ts
+++ b/src/lib/axiosConfig.ts
@@ -1,17 +1,8 @@
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { getToken, setToken, clearToken } from './tokenStore';
 
-function normalizeBase(url?: string | null) {
-  if (!url) return null;
-  return url.replace(/\/+$/, ''); 
-}
-
-const ENV_BASE = normalizeBase(process.env.NEXT_PUBLIC_API_BASE || null);
-const baseURL =
-  ENV_BASE ||
-  (process.env.NODE_ENV !== 'production'
-    ? 'http://localhost:3200/api/v1'
-    : undefined);
+// Always proxy through Next.js API routes
+const baseURL = '/api';
 
 if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
   console.log('[axios] baseURL =', baseURL);
@@ -20,10 +11,10 @@ if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
 }
 
 /* ------------------------- Cliente Axios ------------------------- */
-const api = axios.create({
+export const api = axios.create({
   baseURL,
-  withCredentials: true,           
-  timeout: 15000,                 
+  withCredentials: true,
+  timeout: 15000,
   headers: {
     Accept: 'application/json',
     'X-Requested-With': 'XMLHttpRequest',

--- a/src/lib/session.tsx
+++ b/src/lib/session.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import { api } from './axiosConfig';
+
+interface Page { url: string }
+interface Me { pages: Page[]; roles?: string[] }
+
+interface SessionValue {
+  me: Me | null;
+  loading: boolean;
+  refreshMe: () => Promise<void>;
+}
+
+const SessionContext = createContext<SessionValue>({
+  me: null,
+  loading: true,
+  refreshMe: async () => {},
+});
+
+export function SessionProvider({ children }: { children: React.ReactNode }) {
+  const [me, setMe] = useState<Me | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refreshMe = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get<Me>('/users/me');
+      setMe(data);
+    } catch (e) {
+      setMe(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshMe();
+  }, [refreshMe]);
+
+  return (
+    <SessionContext.Provider value={{ me, loading, refreshMe }}>
+      {children}
+    </SessionContext.Provider>
+  );
+}
+
+export function useSession() {
+  return useContext(SessionContext);
+}


### PR DESCRIPTION
## Summary
- proxy backend routes for paginas, roles, users, and auth refresh
- configure axios to use `/api` with automatic refresh handling
- add session context and page guard to filter admin menu

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0c2db8b188332a1fef40ae2967a08