### PR TITLE
feat: add roles management admin screen

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -18,7 +18,7 @@ import {
   SidebarTrigger,
   SidebarFooter,
 } from '@/components/ui/sidebar';
-import { FilePlus2, FolderKanban, ShieldCheck, Users, LogOut, Settings, Bell, Menu, FileText, PanelLeft } from 'lucide-react';
+import { FilePlus2, FolderKanban, ShieldCheck, Users, LogOut, Settings, Bell, Menu, FileText, PanelLeft, Key } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -60,6 +60,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     { href: '/admin/documentos', label: 'Documentos', icon: FolderKanban },
     { href: '/admin/mis-documentos', label: 'Mis Documentos', icon: FileText },
     { href: '/admin/usuarios', label: 'Usuarios', icon: Users },
+    { href: '/admin/roles', label: 'Roles', icon: Key },
     { href: '/admin/supervision', label: 'Supervisión', icon: ShieldCheck },
   ];
 

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { RolesTable } from '@/components/roles-table';
+import { getRoles, createRole, updateRole, deleteRole, restoreRole, type Role } from '@/services/roleService';
+import { useToast } from '@/hooks/use-toast';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function RolesPage() {
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showInactive, setShowInactive] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const fetchRoles = async () => {
+      setIsLoading(true);
+      try {
+        const data = await getRoles(showInactive);
+        setRoles(data);
+      } catch (error) {
+        toast({
+          variant: 'destructive',
+          title: 'Error al cargar roles',
+          description: 'No se pudieron obtener los roles.',
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchRoles();
+  }, [showInactive, toast]);
+
+  const handleSaveRole = async (role: Partial<Role>) => {
+    try {
+      let saved: Role;
+      if (role.id) {
+        saved = await updateRole(role.id, role);
+        setRoles(prev => prev.map(r => r.id === saved.id ? saved : r));
+        toast({ title: 'Rol actualizado', description: 'El rol ha sido actualizado.' });
+      } else {
+        saved = await createRole(role as any);
+        setRoles(prev => [...prev, saved]);
+        toast({ title: 'Rol creado', description: 'El nuevo rol ha sido agregado.' });
+      }
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al guardar',
+        description: 'Hubo un problema al guardar el rol.',
+      });
+      throw error;
+    }
+  };
+
+  const handleDeleteRole = async (id: string) => {
+    try {
+      await deleteRole(id);
+      setRoles(prev => prev.map(r => r.id === id ? { ...r, activo: false } : r));
+      toast({ variant: 'destructive', title: 'Rol inactivado', description: 'El rol ha sido marcado como inactivo.' });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al eliminar',
+        description: 'Hubo un problema al eliminar el rol.',
+      });
+    }
+  };
+
+  const handleRestoreRole = async (id: string) => {
+    try {
+      const restored = await restoreRole(id);
+      setRoles(prev => prev.map(r => r.id === id ? restored : r));
+      toast({ title: 'Rol restaurado', description: 'El rol ha sido activado nuevamente.' });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al restaurar',
+        description: 'Hubo un problema al restaurar el rol.',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-10 w-1/4" />
+          <div className="flex gap-2">
+            <Skeleton className="h-10 w-32" />
+            <Skeleton className="h-10 w-32" />
+          </div>
+        </div>
+        <Skeleton className="h-[600px] w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full">
+      <RolesTable
+        roles={roles}
+        showInactive={showInactive}
+        onToggleInactive={setShowInactive}
+        onSaveRole={handleSaveRole}
+        onDeleteRole={handleDeleteRole}
+        onRestoreRole={handleRestoreRole}
+      />
+    </div>
+  );
+}
+

--- a/src/components/role-form-modal.tsx
+++ b/src/components/role-form-modal.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Loader2 } from "lucide-react";
+import type { Role } from "@/services/roleService";
+
+export type RoleForm = Pick<Role, "id" | "nombre" | "descripcion">;
+
+interface RoleFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (role: RoleForm) => Promise<void> | void;
+  role?: RoleForm;
+}
+
+const formSchema = z.object({
+  id: z.string().optional(),
+  nombre: z.string().min(1, "El nombre es requerido."),
+  descripcion: z.string().optional(),
+});
+
+const defaultValues: RoleForm = { nombre: "", descripcion: "" };
+
+export function RoleFormModal({ isOpen, onClose, onSave, role }: RoleFormModalProps) {
+  const form = useForm<RoleForm>({
+    resolver: zodResolver(formSchema),
+    defaultValues: role ?? defaultValues,
+  });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(role ?? defaultValues);
+    }
+  }, [isOpen, role, form]);
+
+  const handleSubmit = async (data: RoleForm) => {
+    setLoading(true);
+    try {
+      await onSave(data);
+      onClose();
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const message = (err.response?.data as any)?.message;
+        if (message) {
+          form.setError("nombre", { type: "server", message });
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="glassmorphism sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{role ? "Editar Rol" : "Crear Rol"}</DialogTitle>
+          <DialogDescription>
+            {role ? "Actualice los detalles del rol." : "Complete los campos para crear un nuevo rol."}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="nombre"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Nombre del rol" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="descripcion"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Descripción del rol" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Guardar
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/roles-table.tsx
+++ b/src/components/roles-table.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import React, { useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Search, MoreHorizontal, Edit, Trash2, Plus, RotateCcw } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { RoleFormModal, RoleForm } from './role-form-modal';
+import type { Role } from '@/services/roleService';
+import { format } from 'date-fns';
+
+interface RolesTableProps {
+  roles: Role[];
+  showInactive: boolean;
+  onToggleInactive: (checked: boolean) => void;
+  onSaveRole: (role: RoleForm) => Promise<void>;
+  onDeleteRole: (id: string) => Promise<void> | void;
+  onRestoreRole: (id: string) => Promise<void> | void;
+}
+
+export function RolesTable({ roles, showInactive, onToggleInactive, onSaveRole, onDeleteRole, onRestoreRole }: RolesTableProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedRole, setSelectedRole] = useState<Role | undefined>(undefined);
+
+  const filteredRoles = useMemo(
+    () => roles.filter(r => r.nombre.toLowerCase().includes(searchTerm.toLowerCase())),
+    [roles, searchTerm]
+  );
+
+  const openModal = (role?: Role) => {
+    setSelectedRole(role);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedRole(undefined);
+  };
+
+  const handleSave = async (role: RoleForm) => {
+    await onSaveRole(role);
+    closeModal();
+  };
+
+  return (
+    <>
+      <Card className="w-full h-full flex flex-col glassmorphism">
+        <CardHeader>
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div className="space-y-1.5">
+              <CardTitle>Gestión de Roles ({roles.length})</CardTitle>
+              <CardDescription>Administre los roles de la plataforma.</CardDescription>
+            </div>
+            <div className="flex items-center gap-2 flex-wrap justify-end">
+              <div className="relative w-full md:w-auto flex-grow">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Buscar roles..."
+                  className="pl-8"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch id="show-inactive" checked={showInactive} onCheckedChange={onToggleInactive} />
+                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Ver inactivos</label>
+              </div>
+              <Button onClick={() => openModal()}>
+                <Plus className="mr-2 h-4 w-4" />
+                Crear Rol
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex-grow overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nombre</TableHead>
+                <TableHead className="hidden md:table-cell">Descripción</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead className="hidden md:table-cell">Fecha</TableHead>
+                <TableHead>Acciones</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredRoles.map(role => (
+                <TableRow key={role.id}>
+                  <TableCell className="font-medium">{role.nombre}</TableCell>
+                  <TableCell className="hidden md:table-cell">{role.descripcion}</TableCell>
+                  <TableCell>
+                    <Badge variant={role.activo ? 'default' : 'secondary'}>
+                      {role.activo ? 'Activa' : 'Inactiva'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    {role.createdAt ? format(new Date(role.createdAt), 'dd/MM/yyyy') : ''}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                          <span className="sr-only">Abrir menú</span>
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => openModal(role)}>
+                          <Edit className="mr-2 h-4 w-4" />
+                          <span>Editar</span>
+                        </DropdownMenuItem>
+                        {role.activo ? (
+                          <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={() => onDeleteRole(role.id!)}>
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            <span>Eliminar</span>
+                          </DropdownMenuItem>
+                        ) : (
+                          <DropdownMenuItem onClick={() => onRestoreRole(role.id!)}>
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                            <span>Restaurar</span>
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <RoleFormModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        onSave={handleSave}
+        role={selectedRole}
+      />
+    </>
+  );
+}
+

--- a/src/services/roleService.ts
+++ b/src/services/roleService.ts
@@ -1,0 +1,51 @@
+import api from '@/lib/axiosConfig';
+
+export interface Role {
+  id?: string;
+  nombre: string;
+  descripcion?: string;
+  activo: boolean;
+  createdAt: string;
+}
+
+function mapRoleFromApi(r: any): Role {
+  return {
+    id: r.id,
+    nombre: r.nombre,
+    descripcion: r.descripcion,
+    activo: r.activo,
+    createdAt: r.created_at || r.createdAt,
+  };
+}
+
+function mapRoleToApi(r: Partial<Role>) {
+  return {
+    ...(r.nombre !== undefined && { nombre: r.nombre }),
+    ...(r.descripcion !== undefined && { descripcion: r.descripcion }),
+  };
+}
+
+export async function getRoles(all = false): Promise<Role[]> {
+  const res = await api.get(`/roles?all=${all ? 1 : 0}`);
+  return Array.isArray(res.data) ? res.data.map(mapRoleFromApi) : [];
+}
+
+export async function createRole(role: Omit<Role, 'id' | 'activo' | 'createdAt'>): Promise<Role> {
+  const res = await api.post('/roles', mapRoleToApi(role));
+  return mapRoleFromApi(res.data);
+}
+
+export async function updateRole(id: string, role: Partial<Role>): Promise<Role> {
+  const res = await api.patch(`/roles/${id}`, mapRoleToApi(role));
+  return mapRoleFromApi(res.data);
+}
+
+export async function deleteRole(id: string): Promise<void> {
+  await api.delete(`/roles/${id}`);
+}
+
+export async function restoreRole(id: string): Promise<Role> {
+  const res = await api.patch(`/roles/${id}/restore`);
+  return mapRoleFromApi(res.data);
+}
+


### PR DESCRIPTION
## Summary
- add sidebar entry and page for managing roles
- create roles table and modal for creating/editing roles
- implement role service using Axios with soft delete and restore

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0c55ee64c833281d2f900c5515805