### PR TITLE
feat: add admin page and permission management

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -18,7 +18,7 @@ import {
   SidebarTrigger,
   SidebarFooter,
 } from '@/components/ui/sidebar';
-import { FilePlus2, FolderKanban, ShieldCheck, Users, LogOut, Settings, Bell, Menu, FileText, PanelLeft, Key } from 'lucide-react';
+import { FilePlus2, FolderKanban, ShieldCheck, Users, LogOut, Settings, Bell, Menu, FileText, PanelLeft, Key, File as FileIcon, Shield as ShieldIcon } from 'lucide-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
@@ -61,6 +61,8 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     { href: '/admin/mis-documentos', label: 'Mis Documentos', icon: FileText },
     { href: '/admin/usuarios', label: 'Usuarios', icon: Users },
     { href: '/admin/roles', label: 'Roles', icon: Key },
+    { href: '/admin/page', label: 'Páginas', icon: FileIcon },
+    { href: '/admin/permission', label: 'Permisos', icon: ShieldIcon },
     { href: '/admin/supervision', label: 'Supervisión', icon: ShieldCheck },
   ];
 

--- a/src/app/admin/page/page.tsx
+++ b/src/app/admin/page/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import { PagesTable } from '@/components/pages-table';
+import { getPages, createPage, updatePage, deletePage, restorePage, type Page } from '@/services/pageService';
+import { useToast } from '@/hooks/use-toast';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function PageAdminPage() {
+  const [pages, setPages] = useState<Page[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showInactive, setShowInactive] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    const fetchPages = async () => {
+      setIsLoading(true);
+      try {
+        const data = await getPages(showInactive);
+        setPages(data);
+      } catch (error) {
+        toast({
+          variant: 'destructive',
+          title: 'Error al cargar páginas',
+          description: 'No se pudieron obtener las páginas.',
+        });
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchPages();
+  }, [showInactive, toast]);
+
+  const handleSavePage = async (page: Partial<Page>) => {
+    try {
+      let saved: Page;
+      if (page.id) {
+        saved = await updatePage(page.id, page);
+        setPages(prev => prev.map(p => p.id === saved.id ? saved : p));
+        toast({ title: 'Página actualizada', description: 'La página ha sido actualizada.' });
+      } else {
+        saved = await createPage(page as any);
+        setPages(prev => [...prev, saved]);
+        toast({ title: 'Página creada', description: 'La nueva página ha sido agregada.' });
+      }
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al guardar',
+        description: 'Hubo un problema al guardar la página.',
+      });
+      throw error;
+    }
+  };
+
+  const handleDeletePage = async (id: number) => {
+    try {
+      await deletePage(id);
+      setPages(prev => prev.map(p => p.id === id ? { ...p, activo: false } : p));
+      toast({ variant: 'destructive', title: 'Página inactivada', description: 'La página ha sido marcada como inactiva.' });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al eliminar',
+        description: 'Hubo un problema al eliminar la página.',
+      });
+    }
+  };
+
+  const handleRestorePage = async (id: number) => {
+    try {
+      const restored = await restorePage(id);
+      setPages(prev => prev.map(p => p.id === id ? restored : p));
+      toast({ title: 'Página restaurada', description: 'La página ha sido activada nuevamente.' });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al restaurar',
+        description: 'Hubo un problema al restaurar la página.',
+      });
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-10 w-1/4" />
+          <div className="flex gap-2">
+            <Skeleton className="h-10 w-32" />
+            <Skeleton className="h-10 w-32" />
+          </div>
+        </div>
+        <Skeleton className="h-[600px] w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full">
+      <PagesTable
+        pages={pages}
+        showInactive={showInactive}
+        onToggleInactive={setShowInactive}
+        onSavePage={handleSavePage}
+        onDeletePage={handleDeletePage}
+        onRestorePage={handleRestorePage}
+      />
+    </div>
+  );
+}
+

--- a/src/app/admin/permission/page.tsx
+++ b/src/app/admin/permission/page.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import React, { useEffect, useState, useMemo } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Loader2 } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { getRoles, type Role } from '@/services/roleService';
+import { getPages, getRolePages, updateRolePages, type Page } from '@/services/pageService';
+
+export default function PermissionPage() {
+  const { toast } = useToast();
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [pages, setPages] = useState<Page[]>([]);
+  const [selectedRole, setSelectedRole] = useState<string>('');
+  const [assignedIds, setAssignedIds] = useState<number[]>([]);
+  const [selectedAvailable, setSelectedAvailable] = useState<number[]>([]);
+  const [selectedAssigned, setSelectedAssigned] = useState<number[]>([]);
+  const [loadingList, setLoadingList] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    const loadBase = async () => {
+      try {
+        const [rolesData, pagesData] = await Promise.all([getRoles(), getPages(false)]);
+        setRoles(rolesData.filter(r => r.activo));
+        setPages(pagesData.filter(p => p.activo));
+      } catch (error) {
+        toast({ variant: 'destructive', title: 'Error al cargar datos', description: 'No se pudieron obtener roles o páginas.' });
+      }
+    };
+    loadBase();
+  }, [toast]);
+
+  useEffect(() => {
+    const loadAssigned = async () => {
+      if (!selectedRole) {
+        setAssignedIds([]);
+        return;
+      }
+      setLoadingList(true);
+      try {
+        const ids = await getRolePages(selectedRole);
+        setAssignedIds(ids);
+      } catch (error) {
+        toast({ variant: 'destructive', title: 'Error al cargar permisos', description: 'No se pudieron obtener las páginas asignadas.' });
+      } finally {
+        setLoadingList(false);
+        setSelectedAvailable([]);
+        setSelectedAssigned([]);
+      }
+    };
+    loadAssigned();
+  }, [selectedRole, toast]);
+
+  const availablePages = useMemo(() => pages.filter(p => !assignedIds.includes(p.id!)), [pages, assignedIds]);
+  const assignedPages = useMemo(() => pages.filter(p => assignedIds.includes(p.id!)), [pages, assignedIds]);
+
+  const moveToAssigned = () => {
+    setAssignedIds(prev => [...prev, ...selectedAvailable]);
+    setSelectedAvailable([]);
+  };
+  const moveToAvailable = () => {
+    setAssignedIds(prev => prev.filter(id => !selectedAssigned.includes(id)));
+    setSelectedAssigned([]);
+  };
+  const chooseAll = () => {
+    setAssignedIds(pages.map(p => p.id!));
+    setSelectedAvailable([]);
+    setSelectedAssigned([]);
+  };
+
+  const handleSave = async () => {
+    if (!selectedRole) return;
+    setSaving(true);
+    try {
+      await updateRolePages(selectedRole, assignedIds);
+      toast({ title: 'Permisos actualizados', description: 'Los permisos han sido guardados.' });
+    } catch (error) {
+      toast({ variant: 'destructive', title: 'Error al guardar', description: 'Hubo un problema al guardar los permisos.' });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card className="w-full h-full flex flex-col glassmorphism">
+      <CardHeader className="space-y-4">
+        <div>
+          <CardTitle>Permisos por Rol</CardTitle>
+          <CardDescription>Asigne las páginas activas a cada rol.</CardDescription>
+        </div>
+        <Select value={selectedRole} onValueChange={setSelectedRole}>
+          <SelectTrigger className="w-[240px]">
+            <SelectValue placeholder="Seleccione un rol" />
+          </SelectTrigger>
+          <SelectContent>
+            {roles.map(r => (
+              <SelectItem key={r.id} value={r.id!}>
+                {r.nombre}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4 flex-1">
+        {loadingList ? (
+          <div className="flex-1 flex items-center justify-center">
+            <Loader2 className="h-6 w-6 animate-spin" />
+          </div>
+        ) : (
+          <div className="flex flex-1 gap-4">
+            <div className="flex-1 border rounded p-2 overflow-y-auto">
+              <h3 className="font-semibold mb-2">No asignadas</h3>
+              <div className="space-y-1">
+                {availablePages.map(p => (
+                  <label key={p.id} className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={selectedAvailable.includes(p.id!)}
+                      onCheckedChange={(checked) => {
+                        if (checked) setSelectedAvailable(prev => [...prev, p.id!]);
+                        else setSelectedAvailable(prev => prev.filter(id => id !== p.id));
+                      }}
+                    />
+                    <span>{p.nombre}</span>
+                  </label>
+                ))}
+                {availablePages.length === 0 && (
+                  <p className="text-sm text-muted-foreground">Sin páginas</p>
+                )}
+              </div>
+            </div>
+            <div className="flex flex-col justify-center gap-2">
+              <Button variant="outline" onClick={moveToAssigned} disabled={selectedAvailable.length === 0}>
+                →
+              </Button>
+              <Button variant="outline" onClick={moveToAvailable} disabled={selectedAssigned.length === 0}>
+                ←
+              </Button>
+              <Button variant="outline" onClick={chooseAll} disabled={availablePages.length === 0}>
+                Elegir todos
+              </Button>
+            </div>
+            <div className="flex-1 border rounded p-2 overflow-y-auto">
+              <h3 className="font-semibold mb-2">Asignadas</h3>
+              <div className="space-y-1">
+                {assignedPages.map(p => (
+                  <label key={p.id} className="flex items-center space-x-2">
+                    <Checkbox
+                      checked={selectedAssigned.includes(p.id!)}
+                      onCheckedChange={(checked) => {
+                        if (checked) setSelectedAssigned(prev => [...prev, p.id!]);
+                        else setSelectedAssigned(prev => prev.filter(id => id !== p.id));
+                      }}
+                    />
+                    <span>{p.nombre}</span>
+                  </label>
+                ))}
+                {assignedPages.length === 0 && (
+                  <p className="text-sm text-muted-foreground">Sin páginas</p>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
+        <div className="flex justify-end">
+          <Button onClick={handleSave} disabled={!selectedRole || saving}>
+            {saving && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Guardar
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+

--- a/src/app/api/paginas/[id]/restore/route.ts
+++ b/src/app/api/paginas/[id]/restore/route.ts
@@ -19,18 +19,7 @@ async function proxy(req: NextRequest, target: string) {
   return new NextResponse(data, { status: resp.status, headers: respHeaders });
 }
 
-export async function GET(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  return proxy(req, `${API_BASE}/paginas/${params.id}/restore`);
 }
 
-export async function POST(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
-}
-
-export async function PATCH(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
-}
-
-export async function DELETE(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
-}

--- a/src/components/page-form-modal.tsx
+++ b/src/components/page-form-modal.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import axios from "axios";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Loader2 } from "lucide-react";
+import type { Page } from "@/services/pageService";
+
+export type PageForm = Pick<Page, "id" | "nombre" | "url" | "descripcion">;
+
+interface PageFormModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (page: PageForm) => Promise<void> | void;
+  page?: PageForm;
+}
+
+const formSchema = z.object({
+  id: z.number().optional(),
+  nombre: z.string().min(1, "El nombre es requerido."),
+  url: z.string().min(1, "La URL es requerida."),
+  descripcion: z.string().optional(),
+});
+
+const defaultValues: PageForm = { nombre: "", url: "", descripcion: "" } as PageForm;
+
+export function PageFormModal({ isOpen, onClose, onSave, page }: PageFormModalProps) {
+  const form = useForm<PageForm>({
+    resolver: zodResolver(formSchema),
+    defaultValues: page ?? defaultValues,
+  });
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      form.reset(page ?? defaultValues);
+    }
+  }, [isOpen, page, form]);
+
+  const handleSubmit = async (data: PageForm) => {
+    setLoading(true);
+    try {
+      await onSave(data);
+      onClose();
+    } catch (err) {
+      if (axios.isAxiosError(err)) {
+        const message = (err.response?.data as any)?.message;
+        if (message) {
+          form.setError("nombre", { type: "server", message });
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="glassmorphism sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{page ? "Editar Página" : "Crear Página"}</DialogTitle>
+          <DialogDescription>
+            {page
+              ? "Actualice los detalles de la página."
+              : "Complete los campos para crear una nueva página."}
+          </DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="nombre"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nombre</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Nombre de la página" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>URL</FormLabel>
+                  <FormControl>
+                    <Input placeholder="/ruta" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="descripcion"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Input placeholder="Descripción" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={onClose}>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={loading}>
+                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                Guardar
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/pages-table.tsx
+++ b/src/components/pages-table.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import React, { useMemo, useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Search, MoreHorizontal, Edit, Trash2, Plus, RotateCcw } from 'lucide-react';
+import { Switch } from '@/components/ui/switch';
+import { Badge } from '@/components/ui/badge';
+import { PageFormModal, PageForm } from './page-form-modal';
+import type { Page } from '@/services/pageService';
+import { format } from 'date-fns';
+
+interface PagesTableProps {
+  pages: Page[];
+  showInactive: boolean;
+  onToggleInactive: (checked: boolean) => void;
+  onSavePage: (page: PageForm) => Promise<void>;
+  onDeletePage: (id: number) => Promise<void> | void;
+  onRestorePage: (id: number) => Promise<void> | void;
+}
+
+export function PagesTable({ pages, showInactive, onToggleInactive, onSavePage, onDeletePage, onRestorePage }: PagesTableProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedPage, setSelectedPage] = useState<Page | undefined>(undefined);
+
+  const filteredPages = useMemo(
+    () => pages.filter(p => p.nombre.toLowerCase().includes(searchTerm.toLowerCase())),
+    [pages, searchTerm]
+  );
+
+  const openModal = (page?: Page) => {
+    setSelectedPage(page);
+    setIsModalOpen(true);
+  };
+
+  const closeModal = () => {
+    setIsModalOpen(false);
+    setSelectedPage(undefined);
+  };
+
+  const handleSave = async (page: PageForm) => {
+    await onSavePage(page);
+    closeModal();
+  };
+
+  return (
+    <>
+      <Card className="w-full h-full flex flex-col glassmorphism">
+        <CardHeader>
+          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div className="space-y-1.5">
+              <CardTitle>Gestión de Páginas ({pages.length})</CardTitle>
+              <CardDescription>Administre las páginas de la plataforma.</CardDescription>
+            </div>
+            <div className="flex items-center gap-2 flex-wrap justify-end">
+              <div className="relative w-full md:w-auto flex-grow">
+                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Buscar páginas..."
+                  className="pl-8"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch id="show-inactive" checked={showInactive} onCheckedChange={onToggleInactive} />
+                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Ver inactivos</label>
+              </div>
+              <Button onClick={() => openModal()}>
+                <Plus className="mr-2 h-4 w-4" />
+                Crear Página
+              </Button>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="flex-grow overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nombre</TableHead>
+                <TableHead className="hidden md:table-cell">URL</TableHead>
+                <TableHead className="hidden md:table-cell">Descripción</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead className="hidden md:table-cell">Fecha</TableHead>
+                <TableHead>Acciones</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredPages.map(page => (
+                <TableRow key={page.id}>
+                  <TableCell className="font-medium">{page.nombre}</TableCell>
+                  <TableCell className="hidden md:table-cell">{page.url}</TableCell>
+                  <TableCell className="hidden md:table-cell">{page.descripcion}</TableCell>
+                  <TableCell>
+                    <Badge variant={page.activo ? 'default' : 'secondary'}>
+                      {page.activo ? 'Activa' : 'Inactiva'}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    {page.createdAt ? format(new Date(page.createdAt), 'dd/MM/yyyy') : ''}
+                  </TableCell>
+                  <TableCell>
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button variant="ghost" className="h-8 w-8 p-0">
+                          <span className="sr-only">Abrir menú</span>
+                          <MoreHorizontal className="h-4 w-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuItem onClick={() => openModal(page)}>
+                          <Edit className="mr-2 h-4 w-4" />
+                          <span>Editar</span>
+                        </DropdownMenuItem>
+                        {page.activo ? (
+                          <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={() => onDeletePage(page.id!)}>
+                            <Trash2 className="mr-2 h-4 w-4" />
+                            <span>Eliminar</span>
+                          </DropdownMenuItem>
+                        ) : (
+                          <DropdownMenuItem onClick={() => onRestorePage(page.id!)}>
+                            <RotateCcw className="mr-2 h-4 w-4" />
+                            <span>Restaurar</span>
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+      <PageFormModal
+        isOpen={isModalOpen}
+        onClose={closeModal}
+        onSave={handleSave}
+        page={selectedPage}
+      />
+    </>
+  );
+}
+

--- a/src/services/pageService.ts
+++ b/src/services/pageService.ts
@@ -1,0 +1,67 @@
+import api from '@/lib/axiosConfig';
+
+export interface Page {
+  id?: number;
+  nombre: string;
+  url: string;
+  descripcion?: string;
+  activo: boolean;
+  createdAt: string;
+}
+
+function mapPageFromApi(p: any): Page {
+  return {
+    id: p.id,
+    nombre: p.nombre,
+    url: p.url,
+    descripcion: p.descripcion,
+    activo: p.activo,
+    createdAt: p.created_at || p.createdAt,
+  };
+}
+
+function mapPageToApi(p: Partial<Page>) {
+  return {
+    ...(p.nombre !== undefined && { nombre: p.nombre }),
+    ...(p.url !== undefined && { url: p.url }),
+    ...(p.descripcion !== undefined && { descripcion: p.descripcion }),
+  };
+}
+
+export async function getPages(all = false): Promise<Page[]> {
+  const res = await api.get(`/paginas?all=${all ? 1 : 0}`);
+  return Array.isArray(res.data) ? res.data.map(mapPageFromApi) : [];
+}
+
+export async function createPage(page: Omit<Page, 'id' | 'activo' | 'createdAt'>): Promise<Page> {
+  const res = await api.post('/paginas', mapPageToApi(page));
+  return mapPageFromApi(res.data);
+}
+
+export async function updatePage(id: number, page: Partial<Page>): Promise<Page> {
+  const res = await api.patch(`/paginas/${id}`, mapPageToApi(page));
+  return mapPageFromApi(res.data);
+}
+
+export async function deletePage(id: number): Promise<void> {
+  await api.delete(`/paginas/${id}`);
+}
+
+export async function restorePage(id: number): Promise<Page> {
+  const res = await api.patch(`/paginas/${id}/restore`);
+  return mapPageFromApi(res.data);
+}
+
+export async function getRolePages(roleId: string): Promise<number[]> {
+  const res = await api.get(`/roles/${roleId}/paginas`);
+  return Array.isArray(res.data?.paginaIds)
+    ? res.data.paginaIds
+    : Array.isArray(res.data)
+      ? res.data
+      : [];
+}
+
+export async function updateRolePages(roleId: string, paginaIds: number[]): Promise<void> {
+  await api.put(`/roles/${roleId}/paginas`, { paginaIds });
+}
+


### PR DESCRIPTION
## Summary
- add Page service with role page assignment helpers
- implement admin CRUD UI for pages with soft delete and restore
- add role permission page with dual list selection
- expose paginas endpoints through Next.js API proxies

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c0c71209288332afb0b34f92c7f72d