### PR TITLE
feat: standardize API proxy and session handling

### DIFF
--- a/DOCS_ROUTES.md
+++ b/DOCS_ROUTES.md
@@ -1,0 +1,52 @@
+# DOCS_ROUTES
+
+## Rutas del App Router
+- /admin/asignaciones
+- /admin/documentos
+- /admin/mis-documentos
+- /admin/page
+- /admin/permission
+- /admin/roles
+- /admin/supervision
+- /admin/usuarios
+- /documento/[id]
+- /general
+
+## Ítems del menú
+- Asignaciones — /admin/asignaciones
+- Documentos — /admin/documentos
+- Mis Documentos — /admin/mis-documentos
+- Usuarios — /admin/usuarios
+- Roles — /admin/roles
+- Páginas — /admin/page
+- Permisos — /admin/permission
+- Supervisión — /admin/supervision
+- Mis Documentos — /general
+
+## Menú vs Páginas
+| Ítem | Ruta | Existe |
+|---|---|---|
+| Asignaciones | /admin/asignaciones | OK |
+| Documentos | /admin/documentos | OK |
+| Mis Documentos | /admin/mis-documentos | OK |
+| Usuarios | /admin/usuarios | OK |
+| Roles | /admin/roles | OK |
+| Páginas | /admin/page | OK |
+| Permisos | /admin/permission | OK |
+| Supervisión | /admin/supervision | OK |
+| Mis Documentos | /general | OK |
+
+## Desalineaciones
+No se encontraron desalineaciones.
+
+## URL sugeridas para backend
+- /admin/asignaciones
+- /admin/documentos
+- /admin/mis-documentos
+- /admin/usuarios
+- /admin/roles
+- /admin/page
+- /admin/permission
+- /admin/supervision
+- /general
+- /documento/[id]

--- a/public/routes_inventory.json
+++ b/public/routes_inventory.json
@@ -1,0 +1,64 @@
+{
+  "appRoutes": [
+    "/admin/asignaciones",
+    "/admin/documentos",
+    "/admin/mis-documentos",
+    "/admin/page",
+    "/admin/permission",
+    "/admin/roles",
+    "/admin/supervision",
+    "/admin/usuarios",
+    "/documento/[id]",
+    "/general"
+  ],
+  "menuItems": [
+    {
+      "label": "Asignaciones",
+      "href": "/admin/asignaciones"
+    },
+    {
+      "label": "Documentos",
+      "href": "/admin/documentos"
+    },
+    {
+      "label": "Mis Documentos",
+      "href": "/admin/mis-documentos"
+    },
+    {
+      "label": "Usuarios",
+      "href": "/admin/usuarios"
+    },
+    {
+      "label": "Roles",
+      "href": "/admin/roles"
+    },
+    {
+      "label": "Páginas",
+      "href": "/admin/page"
+    },
+    {
+      "label": "Permisos",
+      "href": "/admin/permission"
+    },
+    {
+      "label": "Supervisión",
+      "href": "/admin/supervision"
+    },
+    {
+      "label": "Mis Documentos",
+      "href": "/general"
+    }
+  ],
+  "suggestedBackendPageUrls": [
+    "/admin/asignaciones",
+    "/admin/documentos",
+    "/admin/mis-documentos",
+    "/admin/usuarios",
+    "/admin/roles",
+    "/admin/page",
+    "/admin/permission",
+    "/admin/supervision",
+    "/general",
+    "/documento/[id]"
+  ]
+}

--- a/src/app/admin/asignaciones/page.tsx
+++ b/src/app/admin/asignaciones/page.tsx
@@ -9,6 +9,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import { Upload, Search, Loader2 } from "lucide-react";
+import { api } from "@/lib/axiosConfig";
 import { getUsers, type User as ApiUser } from "@/lib/data";
 import { useToast } from "@/hooks/use-toast";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -143,9 +144,7 @@ export default function AsignacionesPage() {
     try {
       const formData = new FormData();
       formData.append("file", pdfFile);
-      const response = await fetch("/api/upload", { method: "POST", body: formData });
-      if (!response.ok) throw new Error("Error al subir el archivo.");
-      const result = await response.json();
+      const { data: result } = await api.post('/upload', formData, { headers: { 'Content-Type': 'multipart/form-data' } });
       uploadedPdfPath = result.filePath;
       toast({ title: "Archivo Subido", description: "El PDF se guardó en el servidor." });
     } catch (error) {
@@ -177,13 +176,7 @@ export default function AsignacionesPage() {
     };
 
     try {
-      const response = await fetch("/api/documents", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(newDocument),
-      });
-      if (!response.ok) throw new Error("Error al crear el documento.");
-      const createdDoc = await response.json();
+      const { data: createdDoc } = await api.post('/documents', newDocument);
 
       toast({ title: "Documento Enviado", description: "El documento se envió para firma." });
 

--- a/src/app/admin/documentos/page.tsx
+++ b/src/app/admin/documentos/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import React, { useState, useEffect } from 'react';
@@ -6,6 +5,7 @@ import { DocumentsTable } from "@/components/documents-table";
 import { Document } from "@/lib/data";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
+import { api } from '@/lib/axiosConfig';
 
 export default function DocumentosPage() {
   const [documents, setDocuments] = useState<Document[]>([]);
@@ -15,11 +15,7 @@ export default function DocumentosPage() {
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
-        const response = await fetch('/api/documents');
-        if (!response.ok) {
-          throw new Error('Failed to fetch documents');
-        }
-        const data = await response.json();
+        const { data } = await api.get('/documents');
         setDocuments(data);
       } catch (error) {
         toast({
@@ -54,8 +50,8 @@ export default function DocumentosPage() {
 
   return (
     <div className="h-full">
-        <DocumentsTable 
-            documents={documents} 
+        <DocumentsTable
+            documents={documents}
             title="Gestión de Documentos"
             description="Visualice, busque y gestione todos los documentos de la plataforma."
         />

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -68,6 +68,13 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
 
   const menuItems = allMenuItems.filter(item => me?.pages?.some(p => p.url === item.href));
 
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production') {
+      console.log('me.pages', me?.pages?.map(p => p.url));
+      console.log('sidebar items', menuItems.map(i => i.href));
+    }
+  }, [me, menuItems]);
+
   const getPageTitle = () => {
     if (userRole === 'supervisor') return 'Supervisión';
     return allMenuItems.find(item => pathname.startsWith(item.href))?.label || 'Dashboard';

--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import React, { useState, useEffect } from 'react';
@@ -6,6 +5,7 @@ import { DocumentsTable } from "@/components/documents-table";
 import { Document } from "@/lib/data";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
+import { api } from '@/lib/axiosConfig';
 
 export default function MisDocumentosPage() {
   const [documents, setDocuments] = useState<Document[]>([]);
@@ -15,14 +15,9 @@ export default function MisDocumentosPage() {
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
-        const response = await fetch('/api/documents');
-        if (!response.ok) {
-          throw new Error('Failed to fetch documents');
-        }
-        const data = await response.json();
-        // In a real app, this would be filtered for the current admin user
-        const adminUserId = '1'; // Assuming admin user has id '1'
-        const userDocuments = data.filter((doc: Document) => 
+        const { data } = await api.get('/documents');
+        const adminUserId = '1';
+        const userDocuments = data.filter((doc: Document) =>
             doc.assignedUsers.some(user => user.id === adminUserId)
         );
         setDocuments(userDocuments);
@@ -53,8 +48,8 @@ export default function MisDocumentosPage() {
 
   return (
     <div className="h-full">
-        <DocumentsTable 
-            documents={documents} 
+        <DocumentsTable
+            documents={documents}
             title="Mis Documentos"
             description="Documentos asignados a usted para revisar y firmar."
         />

--- a/src/app/admin/supervision/page.tsx
+++ b/src/app/admin/supervision/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import React, { useState, useEffect } from 'react';
@@ -6,6 +5,7 @@ import { SupervisionTable } from "@/components/supervision-table";
 import { Document, User } from "@/lib/data";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
+import { api } from '@/lib/axiosConfig';
 
 export default function SupervisionPage() {
     const [documents, setDocuments] = useState<Document[]>([]);
@@ -17,20 +17,11 @@ export default function SupervisionPage() {
         const fetchData = async () => {
             try {
                 const [docsRes, usersRes] = await Promise.all([
-                    fetch('/api/documents'),
-                    fetch('/api/users')
+                    api.get('/documents'),
+                    api.get('/users')
                 ]);
-
-                if (!docsRes.ok || !usersRes.ok) {
-                    throw new Error('Failed to fetch data');
-                }
-
-                const docsData = await docsRes.json();
-                const usersData = await usersRes.json();
-                
-                setDocuments(docsData);
-                setUsers(usersData);
-
+                setDocuments(docsRes.data);
+                setUsers(usersRes.data);
             } catch (error) {
                 toast({
                     variant: 'destructive',
@@ -43,10 +34,10 @@ export default function SupervisionPage() {
         };
         fetchData();
     }, [toast]);
-    
+
     const supervisionDocuments = documents.slice(0, 20).map((doc, index) => ({
         ...doc,
-        sentBy: users.length > 0 ? users[index % users.length] : {} as User, 
+        sentBy: users.length > 0 ? users[index % users.length] : {} as User,
         statusDescription: doc.status === 'Rechazado' ? 'Firma rechazada por Finanzas.' : 'Pendiente de firma por CEO.',
     }));
 
@@ -70,8 +61,8 @@ export default function SupervisionPage() {
 
     return (
       <div className="h-full">
-          <SupervisionTable 
-              documents={supervisionDocuments} 
+          <SupervisionTable
+              documents={supervisionDocuments}
               title="Supervisión de Documentos"
               description="Monitoree el estado y progreso de todos los documentos en tiempo real."
           />

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -1,33 +1,13 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../_proxy';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, { params }: { params: { path: string[] } }) {
-  const target = `${API_BASE}/${params.path.join('/')}`;
-
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-    redirect: 'manual',
-  };
-
-  const resp = await fetch(target, init);
-
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, {
-    status: resp.status,
-    headers: respHeaders,
-  });
+async function handler(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
+  const { path } = await ctx.params;
+  return proxyRequest(req, `/${path.join('/')}`);
 }
 
-export const GET = proxy;
-export const POST = proxy;
-export const PUT = proxy;
-export const PATCH = proxy;
-export const DELETE = proxy;
+export const GET = handler;
+export const POST = handler;
+export const PUT = handler;
+export const PATCH = handler;
+export const DELETE = handler;

--- a/src/app/api/_proxy.ts
+++ b/src/app/api/_proxy.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
+
+export async function proxyRequest(req: NextRequest, targetPath: string) {
+  const headers = new Headers(req.headers);
+  const cookie = req.headers.get('cookie');
+  if (cookie) headers.set('cookie', cookie);
+  headers.delete('host');
+  headers.delete('content-length');
+
+  const init: RequestInit = {
+    method: req.method,
+    headers,
+    redirect: 'manual',
+    credentials: 'include',
+    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
+  };
+
+  const res = await fetch(`${API_BASE}${targetPath}`, init);
+  const data = await res.arrayBuffer();
+  const resHeaders = new Headers(res.headers);
+  resHeaders.set('cache-control', 'no-store');
+
+  const setCookie = (res.headers as any).getSetCookie?.() || (res.headers as any).raw?.()['set-cookie'];
+  if (Array.isArray(setCookie)) {
+    setCookie.forEach((c: string) => resHeaders.append('set-cookie', c));
+  } else if (typeof setCookie === 'string') {
+    resHeaders.append('set-cookie', setCookie);
+  }
+
+  return new NextResponse(data, { status: res.status, headers: resHeaders });
+}

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,24 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, target: string) {
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    redirect: 'manual',
-    credentials: 'include',
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-  };
-  const resp = await fetch(target, init);
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, { status: resp.status, headers: respHeaders });
-}
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../../_proxy';
 
 export async function POST(req: NextRequest) {
-  return proxy(req, `${API_BASE}/auth/refresh`);
+  return proxyRequest(req, '/auth/refresh');
 }

--- a/src/app/api/paginas/[id]/restore/route.ts
+++ b/src/app/api/paginas/[id]/restore/route.ts
@@ -1,25 +1,7 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../../../_proxy';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, target: string) {
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    redirect: 'manual',
-    credentials: 'include',
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-  };
-  const resp = await fetch(target, init);
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+export async function PATCH(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  return proxyRequest(req, `/paginas/${id}/restore`);
 }
-
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
-  return proxy(req, `${API_BASE}/paginas/${params.id}/restore`);
-}
-

--- a/src/app/api/paginas/route.ts
+++ b/src/app/api/paginas/route.ts
@@ -1,36 +1,18 @@
-import { NextRequest, NextResponse } from 'next/server';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, target: string) {
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    redirect: 'manual',
-    credentials: 'include',
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-  };
-  const resp = await fetch(target, init);
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, { status: resp.status, headers: respHeaders });
-}
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../_proxy';
 
 export async function GET(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
+  return proxyRequest(req, '/paginas');
 }
 
 export async function POST(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
+  return proxyRequest(req, '/paginas');
 }
 
 export async function PATCH(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
+  return proxyRequest(req, '/paginas');
 }
 
 export async function DELETE(req: NextRequest) {
-  return proxy(req, `${API_BASE}/paginas`);
+  return proxyRequest(req, '/paginas');
 }

--- a/src/app/api/roles/[id]/paginas/route.ts
+++ b/src/app/api/roles/[id]/paginas/route.ts
@@ -1,28 +1,12 @@
-import { NextRequest, NextResponse } from 'next/server';
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../../../_proxy';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, target: string) {
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    redirect: 'manual',
-    credentials: 'include',
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-  };
-  const resp = await fetch(target, init);
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, { status: resp.status, headers: respHeaders });
+export async function GET(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  return proxyRequest(req, `/roles/${id}/paginas`);
 }
 
-export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
-  return proxy(req, `${API_BASE}/roles/${params.id}/paginas`);
-}
-
-export async function PUT(req: NextRequest, { params }: { params: { id: string } }) {
-  return proxy(req, `${API_BASE}/roles/${params.id}/paginas`);
+export async function PUT(req: NextRequest, ctx: { params: Promise<{ id: string }> }) {
+  const { id } = await ctx.params;
+  return proxyRequest(req, `/roles/${id}/paginas`);
 }

--- a/src/app/api/roles/route.ts
+++ b/src/app/api/roles/route.ts
@@ -1,28 +1,10 @@
-import { NextRequest, NextResponse } from 'next/server';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, target: string) {
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    redirect: 'manual',
-    credentials: 'include',
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-  };
-  const resp = await fetch(target, init);
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, { status: resp.status, headers: respHeaders });
-}
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../_proxy';
 
 export async function GET(req: NextRequest) {
-  return proxy(req, `${API_BASE}/roles`);
+  return proxyRequest(req, '/roles');
 }
 
 export async function POST(req: NextRequest) {
-  return proxy(req, `${API_BASE}/roles`);
+  return proxyRequest(req, '/roles');
 }

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,24 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE!;
-
-async function proxy(req: NextRequest, target: string) {
-  const headers = new Headers(req.headers);
-  headers.delete('host');
-  headers.delete('content-length');
-  const init: RequestInit = {
-    method: req.method,
-    headers,
-    redirect: 'manual',
-    credentials: 'include',
-    body: ['GET', 'HEAD'].includes(req.method) ? undefined : await req.arrayBuffer(),
-  };
-  const resp = await fetch(target, init);
-  const respHeaders = new Headers(resp.headers);
-  const data = await resp.arrayBuffer();
-  return new NextResponse(data, { status: resp.status, headers: respHeaders });
-}
+import { NextRequest } from 'next/server';
+import { proxyRequest } from '../../_proxy';
 
 export async function GET(req: NextRequest) {
-  return proxy(req, `${API_BASE}/users/me`);
+  return proxyRequest(req, '/users/me');
 }

--- a/src/app/general/layout.tsx
+++ b/src/app/general/layout.tsx
@@ -1,11 +1,10 @@
-
 "use client";
 
 import { GeneralHeader } from "@/components/general-header";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { AuthGuard } from "@/components/auth-guard";
-import { getMeOnce } from "@/services/userService";
+import { useSession } from "@/lib/session";
 
 export default function GeneralLayout({
   children,
@@ -14,21 +13,18 @@ export default function GeneralLayout({
 }) {
   const pathname = usePathname();
   const router = useRouter();
+  const { me, loading } = useSession();
 
   useEffect(() => {
-    getMeOnce()
-      .then((user) => {
-        const roles: string[] = user?.roles ?? [];
-        if (roles.includes('ADMIN')) {
-          router.replace('/admin/asignaciones');
-        } else if (roles.includes('SUPERVISOR')) {
-          router.replace('/admin/supervision');
-        }
-      })
-      .catch(() => router.replace('/'));
-  }, [router]);
+    if (loading) return;
+    const roles: string[] = me?.roles ?? [];
+    if (roles.includes('ADMIN')) {
+      router.replace('/admin/asignaciones');
+    } else if (roles.includes('SUPERVISOR')) {
+      router.replace('/admin/supervision');
+    }
+  }, [loading, me, router]);
 
-  // The document detail page will handle its own header
   const isDocumentDetailPage = pathname.startsWith('/documento/');
 
   if (isDocumentDetailPage) {

--- a/src/components/login-form.tsx
+++ b/src/components/login-form.tsx
@@ -14,7 +14,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Loader2, Eye, EyeOff } from "lucide-react";
 import React from "react";
 import { login as authLogin } from "@/services/authService";
-import { getMe } from "@/services/userService";
+import { useSession } from "@/lib/session";
 
 const formSchema = z.object({
   email: z.string().min(1, { message: "El correo es requerido." }),
@@ -24,6 +24,7 @@ const formSchema = z.object({
 export function LoginForm() {
   const router = useRouter();
   const { toast } = useToast();
+  const { refreshMe } = useSession();
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [showPassword, setShowPassword] = React.useState(false);
 
@@ -35,10 +36,10 @@ export function LoginForm() {
   async function onSubmit(values: z.infer<typeof formSchema>) {
     setIsSubmitting(true);
     try {
-      const data = await authLogin(values.email, values.password);
+      await authLogin(values.email, values.password);
       toast({ title: "Inicio de sesión exitoso" });
 
-      const me = await getMe();
+      const me = await refreshMe();
       const roles: string[] = me?.roles ?? [];
 
       if (roles.includes('ADMIN')) {

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -27,7 +27,7 @@ import Cropper from 'react-easy-crop';
 import type { Point, Area } from 'react-easy-crop';
 import getCroppedImg from '@/lib/crop-image';
 import { Slider } from './ui/slider';
-import { getMeOnce } from '@/services/userService';
+import { useSession } from '@/lib/session';
 
 const SettingsDialogContext = React.createContext({
     setOpen: (open: boolean) => {}
@@ -62,6 +62,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false);
   const [theme, setTheme] = useState('light');
   const [userRole, setUserRole] = useState<string | null>(null);
+  const { me } = useSession();
   const { toast } = useToast();
   
   const [currentSignature, setCurrentSignature] = useState<string | null>(null);
@@ -84,15 +85,13 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
     const storedTheme = localStorage.getItem('theme') || 'light';
     setTheme(storedTheme);
     document.documentElement.classList.toggle('dark', storedTheme === 'dark');
-    getMeOnce().then((user) => {
-      const roles: string[] = user?.roles ?? [];
-      const role = roles.includes('ADMIN')
-        ? 'admin'
-        : roles.includes('SUPERVISOR')
-          ? 'supervisor'
-          : 'general';
-      setUserRole(role);
-    });
+    const roles: string[] = me?.roles ?? [];
+    const role = roles.includes('ADMIN')
+      ? 'admin'
+      : roles.includes('SUPERVISOR')
+        ? 'supervisor'
+        : 'general';
+    setUserRole(role);
     
     const savedSignature = localStorage.getItem('userSignature');
     if(savedSignature) {
@@ -103,7 +102,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
         setAvatarImage(savedAvatar);
     }
 
-  }, []);
+  }, [me]);
 
   const handleThemeChange = (isDark: boolean) => {
     const newTheme = isDark ? 'dark' : 'light';
@@ -172,7 +171,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
 
   const onCropComplete = useCallback((croppedArea: Area, croppedAreaPixels: Area) => {
     setCroppedAreaPixels(croppedAreaPixels);
-  }, []);
+  }, [me]);
 
   const showCroppedImage = useCallback(async () => {
     try {

--- a/src/lib/session.tsx
+++ b/src/lib/session.tsx
@@ -1,41 +1,46 @@
 "use client";
 
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
+import React, { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import { api } from './axiosConfig';
 
 interface Page { url: string }
-interface Me { pages: Page[]; roles?: string[] }
+interface Me { pages: Page[]; roles?: string[]; id?: string; email?: string }
 
 interface SessionValue {
   me: Me | null;
   loading: boolean;
-  refreshMe: () => Promise<void>;
+  refreshMe: () => Promise<Me | null>;
 }
 
 const SessionContext = createContext<SessionValue>({
   me: null,
   loading: true,
-  refreshMe: async () => {},
+  refreshMe: async () => null,
 });
 
 export function SessionProvider({ children }: { children: React.ReactNode }) {
   const [me, setMe] = useState<Me | null>(null);
   const [loading, setLoading] = useState(true);
+  const fetched = useRef(false);
 
   const refreshMe = useCallback(async () => {
     setLoading(true);
     try {
       const { data } = await api.get<Me>('/users/me');
       setMe(data);
+      return data;
     } catch (e) {
       setMe(null);
+      return null;
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    refreshMe();
+    if (fetched.current) return;
+    fetched.current = true;
+    void refreshMe();
   }, [refreshMe]);
 
   return (


### PR DESCRIPTION
## Summary
- add reusable Next.js proxy helper with cookie forwarding and catch-all routing
- load user session once and use it across auth, login and sidebar filtering
- document available routes and menu items

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c10d81939c8332b9eb6543a6c1573f