### PR TITLE
Fix cookie-based auth flow with refresh and logout

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -4,7 +4,6 @@
 
 import React, { useEffect } from 'react';
 import { AuthGuard } from '@/components/auth-guard';
-import { logout } from '@/services/authService';
 import { useSession } from '@/lib/session';
 import {
   SidebarProvider,

--- a/src/app/api/[...path]/route.ts
+++ b/src/app/api/[...path]/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from 'next/server';
 import { proxyRequest } from '../_proxy';
 
+export const dynamic = 'force-dynamic';
+
 async function handler(req: NextRequest, ctx: { params: Promise<{ path: string[] }> }) {
   const { path } = await ctx.params;
   return proxyRequest(req, `/${path.join('/')}`);
 }
-
-export const dynamic = 'force-dynamic';
 export const GET = handler;
 export const POST = handler;
 export const PUT = handler;

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -4,5 +4,6 @@ import { proxyRequest } from '../../_proxy';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: NextRequest) {
-  return proxyRequest(req, '/auth/refresh');
+  return proxyRequest(req, '/auth/logout');
 }
+

--- a/src/components/auth-guard.tsx
+++ b/src/components/auth-guard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSession } from '@/lib/session';
 
 interface AuthGuardProps {
@@ -12,20 +12,21 @@ interface AuthGuardProps {
 export function AuthGuard({ children, roles }: AuthGuardProps) {
   const router = useRouter();
   const { me, loading } = useSession();
-  const [authorized, setAuthorized] = useState(false);
 
   useEffect(() => {
     if (loading) return;
-    const userRoles: string[] = me?.roles ?? [];
-    if (me && (!roles || roles.some((r) => userRoles.includes(r)))) {
-      setAuthorized(true);
-    } else {
+    if (!me) {
+      router.replace('/');
+      return;
+    }
+    if (roles && !(me.roles ?? []).some((r) => roles.includes(r))) {
       router.replace('/');
     }
   }, [loading, me, roles, router]);
 
   if (loading) return null;
-  if (!authorized) return null;
+  if (!me) return null;
+  if (roles && !(me.roles ?? []).some((r) => roles.includes(r))) return null;
 
   return <>{children}</>;
 }

--- a/src/lib/session.tsx
+++ b/src/lib/session.tsx
@@ -2,6 +2,7 @@
 
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { api } from './axiosConfig';
+import { clearToken } from './tokenStore';
 
 interface Page { url: string }
 interface Me { pages: Page[]; roles?: string[]; id?: string; email?: string }
@@ -43,7 +44,8 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     try {
       await api.post('/auth/logout');
     } finally {
-      setMe(null); 
+      clearToken();
+      setMe(null);
     }
   }, []);
 
@@ -53,9 +55,9 @@ export function SessionProvider({ children }: { children: React.ReactNode }) {
     void refreshMe();
   }, [refreshMe]);
 
-    const value = useMemo(() => ({ me, loading, refreshMe, signOut }), [me, loading, refreshMe, signOut]);
-    return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
-  }
+  const value = useMemo(() => ({ me, loading, refreshMe, signOut }), [me, loading, refreshMe, signOut]);
+  return <SessionContext.Provider value={value}>{children}</SessionContext.Provider>;
+}
 
 export function useSession() {
   return useContext(SessionContext);


### PR DESCRIPTION
## Summary
- forward cookies and Set-Cookie headers through API proxy and expose auth refresh/logout routes
- refresh axios requests once on 401 and skip logout, clearing token on failure
- load session only once, expose signOut that calls logout endpoint and clears in-memory token

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c138cc4c6483328d62a4302fcadbc8