### PR TITLE
feat: wire admin views to new services

### DIFF
--- a/src/app/admin/asignaciones/page.tsx
+++ b/src/app/admin/asignaciones/page.tsx
@@ -9,7 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Textarea } from "@/components/ui/textarea";
 import { Separator } from "@/components/ui/separator";
 import { Upload, Search, Loader2 } from "lucide-react";
-import { getUsers, getMe, type User as ApiUser } from "@/services/usersService";
+import { getUsers, getMe } from "@/services/usersService";
+import type { User } from "@/lib/data";
 import { createCuadroFirma } from "@/services/documentsService";
 import { useToast } from "@/hooks/use-toast";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
@@ -24,23 +25,7 @@ import {
 } from "@/components/ui/table";
 
 
-type UIUser = {
-  id: string;
-  name: string;
-  position: string;
-  department: string;
-  avatar?: string;
-};
-
-const toUIUser = (u: ApiUser): UIUser => ({
-  id: String(u.id ?? crypto.randomUUID()),
-  name: (u as any).nombre ?? "",
-  position: "—",
-  department: "—",
-  avatar: undefined,
-});
-
-type Signatory = UIUser & { responsibility: "REVISA" | "APRUEBA" | "ENTERADO" | null };
+type Signatory = User & { responsibility: "REVISA" | "APRUEBA" | "ENTERADO" | null };
 
 const getInitials = (name: string) => {
   const parts = name.trim().split(/\s+/);
@@ -52,7 +37,7 @@ export default function AsignacionesPage() {
   const { toast } = useToast();
 
   const [searchTerm, setSearchTerm] = useState("");
-  const [users, setUsers] = useState<UIUser[]>([]);
+  const [users, setUsers] = useState<User[]>([]);
   const [signatories, setSignatories] = useState<Signatory[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [documentContent, setDocumentContent] = useState("");
@@ -65,8 +50,9 @@ export default function AsignacionesPage() {
     let mounted = true;
     (async () => {
       try {
-        const apiUsers = await getUsers();
-        if (mounted) setUsers(apiUsers.map(toUIUser));
+        const data = await getUsers();
+        const list = Array.isArray(data) ? data : [];
+        if (mounted) setUsers(list);
       } catch (err) {
         console.error(err);
         toast({
@@ -94,7 +80,7 @@ export default function AsignacionesPage() {
     return term ? base : base.slice(0, 5);
   }, [users, searchTerm, signatories]);
 
-  const addSignatory = (user: UIUser) => {
+  const addSignatory = (user: User) => {
     setSignatories((prev) =>
       [...prev, { ...user, responsibility: null }].sort((a, b) => a.name.localeCompare(b.name))
     );

--- a/src/app/admin/documentos/page.tsx
+++ b/src/app/admin/documentos/page.tsx
@@ -1,22 +1,21 @@
 "use client";
 
 import React, { useState, useEffect } from 'react';
-import { DocumentsTable } from "@/components/documents-table";
-import { Document } from "@/lib/data";
+import { SupervisionTable } from "@/components/supervision-table";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getSupervisionDocs } from '@/services/documentsService';
+import { getDocumentSupervision, type SupervisionDoc } from '@/services/documentsService';
 
 export default function DocumentosPage() {
-  const [documents, setDocuments] = useState<Document[]>([]);
+  const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const { toast } = useToast();
 
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
-        const data = await getSupervisionDocs();
-        setDocuments(data as Document[]);
+        const { items } = await getDocumentSupervision();
+        setDocuments(Array.isArray(items) ? items : []);
       } catch (error) {
         toast({
           variant: 'destructive',
@@ -50,7 +49,7 @@ export default function DocumentosPage() {
 
   return (
     <div className="h-full">
-        <DocumentsTable
+        <SupervisionTable
             documents={documents}
             title="Gestión de Documentos"
             description="Visualice, busque y gestione todos los documentos de la plataforma."

--- a/src/app/admin/supervision/page.tsx
+++ b/src/app/admin/supervision/page.tsx
@@ -2,21 +2,20 @@
 
 import React, { useState, useEffect } from 'react';
 import { SupervisionTable } from "@/components/supervision-table";
-import { Document } from "@/lib/data";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getSupervisionDocs } from '@/services/documentsService';
+import { getDocumentSupervision, type SupervisionDoc } from '@/services/documentsService';
 
 export default function SupervisionPage() {
-    const [documents, setDocuments] = useState<Document[]>([]);
+    const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const { toast } = useToast();
 
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const data = await getSupervisionDocs();
-                setDocuments(data as Document[]);
+                const { items } = await getDocumentSupervision();
+                setDocuments(Array.isArray(items) ? items : []);
             } catch (error) {
                 toast({
                     variant: 'destructive',

--- a/src/app/admin/usuarios/page.tsx
+++ b/src/app/admin/usuarios/page.tsx
@@ -1,129 +1,67 @@
-'use client'
+'use client';
 
-import React, { useState, useEffect } from 'react'
-import { UsersTable } from '@/components/users-table'
-import { useToast } from '@/hooks/use-toast'
-import { Skeleton } from '@/components/ui/skeleton'
-import { getUsers, createUser, updateUser, deleteUser } from '@/services/usersService'
-import type { User } from '@/lib/data'
-
-/** Convierte el shape del backend (snake_case) a tu modelo UI (camelCase) */
-const toUiUser = (u: any): User => {
-  const ui: any = {
-    // ids como string para tu tabla
-    id: String(u.id ?? u.user_id ?? ''),
-
-    // nombres
-    primerNombre: u.primer_nombre ?? u.primerNombre ?? '',
-    segundoNombre: u.segundo_name ?? u.segundoNombre ?? '',
-    tercerNombre: u.tercer_nombre ?? u.tercerNombre ?? '',
-    primerApellido: u.primer_apellido ?? u.primerApellido ?? '',
-    segundoApellido: u.segundo_apellido ?? u.segundoApellido ?? '',
-    apellidoCasada: u.apellido_casada ?? u.apellidoCasada ?? '',
-
-    // contacto / laborales
-    correoInstitucional: u.correo_institucional ?? u.correoInstitucional ?? '',
-    codigoEmpleado: u.codigo_empleado ?? u.codigoEmpleado ?? '',
-    telefono: u.telefono ?? '',
-
-    // relaciones (numérico o null/undefined, según tu interfaz)
-    posicionId: u.posicion_id ?? u.posicionId ?? null,
-    gerenciaId: u.gerencia_id ?? u.gerenciaId ?? null,
-
-    // estado
-    activo: u.activo ?? true,
-
-    // multimedia / preferencias (ajústalos a tu interfaz si existen)
-    fotoPerfil: u.foto_perfil ?? null,
-    imagenFirma: u.imagen_firma ?? null,
-    configTema: u.config_tema ?? null,
-  }
-
-  // nombre completo si tu `User` requiere `name`
-  ui.name = [
-    ui.primerNombre,
-    ui.segundoNombre,
-    ui.tercerNombre,
-    ui.primerApellido,
-    ui.segundoApellido,
-    ui.apellidoCasada,
-  ]
-    .filter(Boolean)
-    .join(' ')
-
-  // Sugerencia del propio TS: castear a unknown primero
-  return ui as unknown as User
-}
-
+import React, { useState, useEffect } from 'react';
+import { UsersTable } from '@/components/users-table';
+import { useToast } from '@/hooks/use-toast';
+import { Skeleton } from '@/components/ui/skeleton';
+import { getUsers, createUser, updateUser, deleteUser } from '@/services/usersService';
+import type { User } from '@/lib/data';
 
 export default function UsuariosPage() {
-  const [users, setUsers] = useState<User[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const { toast } = useToast()
+  const [users, setUsers] = useState<User[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const { toast } = useToast();
 
-  const getFullName = (u: User) =>
+  const fullName = (u: User) =>
     [u.primerNombre, u.segundoNombre, u.tercerNombre, u.primerApellido, u.segundoApellido, u.apellidoCasada]
       .filter(Boolean)
-      .join(' ')
+      .join(' ');
 
   useEffect(() => {
-    const fetchUsers = async () => {
+    (async () => {
       try {
-        const data = await getUsers()
-        const ui = Array.isArray(data) ? data.map(toUiUser) : []
-        setUsers(ui.sort((a, b) => getFullName(a).localeCompare(getFullName(b))))
-      } catch (error) {
+        const list = await getUsers();
+        const arr = Array.isArray(list) ? list : [];
+        setUsers(arr.sort((a, b) => fullName(a).localeCompare(fullName(b))));
+      } catch {
         toast({
           variant: 'destructive',
           title: 'Error al cargar usuarios',
           description: 'No se pudieron obtener los datos de los usuarios.',
-        })
+        });
       } finally {
-        setIsLoading(false)
+        setIsLoading(false);
       }
-    }
-    fetchUsers()
-  }, [toast])
+    })();
+  }, [toast]);
 
   const handleSaveUser = async (user: User) => {
     try {
       if (!user.id) {
-        const created = await createUser(user as any)
-        const saved = toUiUser(created)
-        setUsers((prev) => [...prev, saved].sort((a, b) => getFullName(a).localeCompare(getFullName(b))))
-        toast({ title: 'Usuario Creado', description: 'El nuevo usuario ha sido agregado exitosamente.' })
+        const created = await createUser(user as any);
+        setUsers((prev) => [...prev, created].sort((a, b) => fullName(a).localeCompare(fullName(b))));
+        toast({ title: 'Usuario Creado', description: 'El nuevo usuario ha sido agregado exitosamente.' });
       } else {
-        const updated = await updateUser(Number(user.id), user as any)
-        const saved = toUiUser(updated)
+        const updated = await updateUser(Number(user.id), user as any);
         setUsers((prev) =>
-          prev
-            .map((u) => (String(u.id) === String(saved.id) ? saved : u))
-            .sort((a, b) => getFullName(a).localeCompare(getFullName(b))),
-        )
-        toast({ title: 'Usuario Actualizado', description: 'Los datos del usuario han sido actualizados.' })
+          prev.map((u) => (String(u.id) === String(updated.id) ? updated : u)).sort((a, b) => fullName(a).localeCompare(fullName(b))),
+        );
+        toast({ title: 'Usuario Actualizado', description: 'Los datos del usuario han sido actualizados.' });
       }
-    } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Error al guardar',
-        description: 'Hubo un problema al guardar los datos del usuario.',
-      })
+    } catch {
+      toast({ variant: 'destructive', title: 'Error al guardar', description: 'No se pudo guardar el usuario.' });
     }
-  }
+  };
 
   const handleDeleteUser = async (userId: string) => {
     try {
-      await deleteUser(Number(userId))
-      setUsers((prev) => prev.filter((u) => String(u.id) !== String(userId)))
-      toast({ variant: 'destructive', title: 'Usuario Eliminado', description: 'El usuario ha sido eliminado.' })
-    } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Error al eliminar',
-        description: 'Hubo un problema al eliminar el usuario.',
-      })
+      await deleteUser(Number(userId));
+      setUsers((prev) => prev.filter((u) => String(u.id) !== String(userId)));
+      toast({ variant: 'destructive', title: 'Usuario Eliminado', description: 'El usuario ha sido eliminado.' });
+    } catch {
+      toast({ variant: 'destructive', title: 'Error al eliminar', description: 'No se pudo eliminar el usuario.' });
     }
-  }
+  };
 
   if (isLoading) {
     return (
@@ -137,12 +75,9 @@ export default function UsuariosPage() {
         </div>
         <Skeleton className="h-[600px] w-full" />
       </div>
-    )
+    );
   }
 
-  return (
-    <div className="h-full">
-      <UsersTable users={users} onSaveUser={handleSaveUser} onDeleteUser={handleDeleteUser} />
-    </div>
-  )
+  return <UsersTable users={users} onSaveUser={handleSaveUser} onDeleteUser={handleDeleteUser} />;
 }
+


### PR DESCRIPTION
## Summary
- fetch users through usersService with consistent loading states
- list signatories using service data and safe array handling
- load documents with getDocumentSupervision and show status counts

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Property 'activo' does not exist on type 'Pagina')*


------
https://chatgpt.com/codex/tasks/task_e_68c4c4844fa48332be7c117657305bb6