### PR TITLE
feat: align document endpoints with backend contract

### DIFF
--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,10 @@
+# .env setup
+
+Create a `.env.local` file and define the backend base URL:
+
+```
+NEXT_PUBLIC_API_BASE=https://api.example.com
+```
+
+All HTTP requests go through the Next.js proxy at `/api/*`, which forwards to `NEXT_PUBLIC_API_BASE` using `src/app/api/_proxy.ts`.
+

--- a/src/app/admin/documentos/page.tsx
+++ b/src/app/admin/documentos/page.tsx
@@ -9,13 +9,17 @@ import { getDocumentSupervision, type SupervisionDoc } from '@/services/document
 export default function DocumentosPage() {
   const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const [meta, setMeta] = useState<any>({});
   const { toast } = useToast();
 
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
-        const { items } = await getDocumentSupervision();
+        const { items, meta } = await getDocumentSupervision({ page, limit });
         setDocuments(Array.isArray(items) ? items : []);
+        setMeta(meta);
       } catch (error) {
         toast({
           variant: 'destructive',
@@ -27,7 +31,7 @@ export default function DocumentosPage() {
       }
     };
     fetchDocuments();
-  }, [toast]);
+  }, [toast, page]);
 
   if (isLoading) {
     return (

--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -35,15 +35,18 @@ function toUiDocument(d: SupervisionDoc): Document {
 export default function MisDocumentosPage() {
   const [documents, setDocuments] = useState<Document[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const [meta, setMeta] = useState<any>({});
   const { toast } = useToast();
 
   useEffect(() => {
     const fetchDocuments = async () => {
       try {
         const me = await getMe();
-        const raw = await getDocumentsByUser(Number(me.id));
-        const items = Array.isArray(raw) ? raw : [];
+        const { items, meta } = await getDocumentsByUser(Number(me.id), { page, limit });
         setDocuments(items.map(toUiDocument));
+        setMeta(meta);
       } catch (error) {
         toast({
           variant: "destructive",
@@ -55,7 +58,7 @@ export default function MisDocumentosPage() {
       }
     };
     fetchDocuments();
-  }, [toast]);
+  }, [toast, page]);
 
   if (isLoading) {
     return (

--- a/src/app/general/page.tsx
+++ b/src/app/general/page.tsx
@@ -6,7 +6,8 @@ import { DocumentsTable } from "@/components/documents-table";
 import { Document } from "@/lib/data";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
-import api from "@/lib/axiosConfig";
+import { getDocumentsByUser, type SupervisionDoc } from "@/services/documentsService";
+import { getMe } from "@/services/usersService";
 
 export default function GeneralPage() {
     const [documents, setDocuments] = useState<Document[]>([]);
@@ -16,10 +17,20 @@ export default function GeneralPage() {
     useEffect(() => {
         const fetchDocuments = async () => {
             try {
-                const { data } = await api.get<Document[]>('/documents');
-                // In a real app, this would be filtered for the current user
-                const userDocuments = data.filter((doc: Document) => doc.id !== 'DOC001');
-                setDocuments(userDocuments);
+                const me = await getMe();
+                const { items } = await getDocumentsByUser(Number(me.id), { page: 1, limit: 20 });
+                const mapped: Document[] = items.map((d: SupervisionDoc) => ({
+                    id: String(d.id),
+                    code: d.codigo ?? '',
+                    name: d.titulo ?? '',
+                    description: d.descripcion ?? '',
+                    sendDate: d.addDate ?? '',
+                    lastStatusChangeDate: d.addDate ?? '',
+                    businessDays: d.diasTranscurridos ?? 0,
+                    status: d.estado,
+                    assignedUsers: [],
+                }));
+                setDocuments(mapped);
             } catch (error) {
                 toast({
                     variant: 'destructive',

--- a/src/lib/responsables.ts
+++ b/src/lib/responsables.ts
@@ -1,0 +1,16 @@
+export interface BuildResponsablesInput {
+  elaboraUserId: number;
+  revisaUserIds?: number[];
+  apruebaUserIds?: number[];
+}
+
+export const buildResponsables = ({
+  elaboraUserId,
+  revisaUserIds = [],
+  apruebaUserIds = [],
+}: BuildResponsablesInput) => ({
+  elabora: { userId: elaboraUserId },
+  revisa: revisaUserIds.map((id) => ({ userId: id })),
+  aprueba: apruebaUserIds.map((id) => ({ userId: id })),
+});
+


### PR DESCRIPTION
## Summary
- use `/documents/cuadro-firmas` contract in document service
- send multipart payloads for creation, updates and signing
- fetch presigned PDF URLs and firmantes in document detail
- add pagination params to document lists
- document API base url in env guide

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c670498e248332b197a8f24c11e3cc