### PR TITLE
feat: add assigned avatars and pagination for documents

### DIFF
--- a/src/lib/avatar.ts
+++ b/src/lib/avatar.ts
@@ -1,0 +1,2 @@
+export const initials = (name: string) =>
+  name?.trim().split(/\s+/).slice(0, 2).map(s => s[0]?.toUpperCase()).join('') || '??';


### PR DESCRIPTION
## Summary
- add avatar initials helper and document service enhancements for assignee summaries
- display up to three assignee avatars with +N indicator in documents table
- implement paginated Mis Documentos page with remote search, filters, and signer modal

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c685a284088332aea37807bf565421