### PR TITLE
feat: align admin document view with user experience

### DIFF
--- a/src/app/admin/documentos/page.tsx
+++ b/src/app/admin/documentos/page.tsx
@@ -1,63 +1,215 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
-import { SupervisionTable } from "@/components/supervision-table";
-import { useToast } from '@/hooks/use-toast';
-import { Skeleton } from '@/components/ui/skeleton';
-import { getDocumentSupervision, type SupervisionDoc } from '@/services/documentsService';
+import React, { useState, useEffect } from "react";
+import { DocumentsTable } from "@/components/documents-table";
+import type { Document } from "@/lib/data";
+import { useToast } from "@/hooks/use-toast";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import {
+  getDocumentSupervision,
+  getFirmantes,
+  type DocumentoRow,
+  type SignerSummary,
+} from "@/services/documentsService";
+import { SignersModal } from "@/components/signers-modal";
+
+function toUiDocument(d: DocumentoRow): Document {
+  const add = d.add_date ?? "";
+  const onlyDate = add ? String(add).split("T")[0] : "";
+  const assignedUsers = (d.firmantesResumen && d.firmantesResumen.length
+    ? d.firmantesResumen
+    : Array.from({ length: 3 }).map((_, i) => ({
+        id: `ph-${i}`,
+        nombre: "",
+        urlFoto: undefined,
+        responsabilidad: "",
+      }))
+  ).map((f) => ({
+    id: String(f.id),
+    name: f.nombre,
+    avatar: f.urlFoto ?? undefined,
+    responsibility: f.responsabilidad,
+    department: "",
+    employeeCode: "",
+  }));
+  const anyDoc: any = {
+    id: String(d.id ?? ""),
+    code: "",
+    name: d.titulo ?? "",
+    description: d.descripcion ?? "",
+    sendDate: onlyDate,
+    status: (d.estado?.nombre ?? "") as Document["status"],
+    businessDays: d.diasTranscurridos ?? 0,
+    assignedUsers,
+  };
+  return anyDoc as Document;
+}
 
 export default function DocumentosPage() {
-  const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
+  const [documents, setDocuments] = useState<Document[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [page, setPage] = useState(1);
   const limit = 10;
   const [meta, setMeta] = useState<any>({});
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState<Document["status"] | "Todos">(
+    "Todos",
+  );
+  const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
+  const [firmantes, setFirmantes] = useState<SignerSummary[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
+  const [counts, setCounts] = useState<
+    Record<Document["status"] | "Todos", number>
+  >({ Todos: 0, Pendiente: 0, "En Progreso": 0, Rechazado: 0, Completado: 0 });
   const { toast } = useToast();
 
   useEffect(() => {
+    const handler = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(handler);
+  }, [searchInput]);
+
+  useEffect(() => {
     const fetchDocuments = async () => {
+      setIsLoading(true);
       try {
-        const { items, meta } = await getDocumentSupervision({ page, limit });
-        setDocuments(Array.isArray(items) ? items : []);
-        setMeta(meta);
+        const params: any = { page, limit, sort: sortOrder };
+        if (search) params.search = search;
+        if (statusFilter !== "Todos") params.estado = statusFilter;
+        const { documentos, meta: metaResp } = await getDocumentSupervision(params);
+        setDocuments(documentos.map(toUiDocument));
+        const m: any = metaResp || {};
+        setMeta({
+          ...m,
+          totalPages: m.totalPages ?? m.lastPage ?? 1,
+        });
       } catch (error) {
         toast({
-          variant: 'destructive',
-          title: 'Error al cargar documentos',
-          description: 'No se pudieron obtener los datos de los documentos.',
+          variant: "destructive",
+          title: "Error al cargar documentos",
+          description: "No se pudieron obtener los datos de los documentos.",
         });
       } finally {
         setIsLoading(false);
       }
     };
     fetchDocuments();
-  }, [toast, page]);
+  }, [toast, page, search, statusFilter, sortOrder]);
+
+  useEffect(() => {
+    const fetchCounts = async () => {
+      try {
+        const statuses: Document["status"][] = [
+          "Pendiente",
+          "En Progreso",
+          "Rechazado",
+          "Completado",
+        ];
+        const res = await Promise.all(
+          statuses.map((st) =>
+            getDocumentSupervision({ page: 1, limit: 1, estado: st, search }),
+          ),
+        );
+        const c: Record<Document["status"] | "Todos", number> = {
+          Todos: 0,
+          Pendiente: 0,
+          "En Progreso": 0,
+          Rechazado: 0,
+          Completado: 0,
+        };
+        statuses.forEach((st, idx) => {
+          const total =
+            res[idx].meta?.totalCount ?? (res[idx].meta as any)?.total ?? 0;
+          c[st] = total;
+          c.Todos += total;
+        });
+        setCounts(c);
+      } catch {
+        /* ignore counts errors */
+      }
+    };
+    fetchCounts();
+  }, [search]);
+
+  const handleAsignadosClick = async (doc: Document) => {
+    setModalOpen(true);
+    setModalLoading(true);
+    try {
+      const data = await getFirmantes(Number(doc.id));
+      setFirmantes(data);
+    } catch {
+      toast({
+        variant: "destructive",
+        title: "Error al cargar firmantes",
+        description: "No se pudieron obtener los firmantes.",
+      });
+      setFirmantes([]);
+    } finally {
+      setModalLoading(false);
+    }
+  };
 
   if (isLoading) {
     return (
       <div className="space-y-4">
-          <div className="flex justify-between items-center">
-              <Skeleton className="h-10 w-1/4" />
-              <Skeleton className="h-10 w-1/3" />
-          </div>
-          <div className="flex gap-2">
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-10 w-24" />
-            <Skeleton className="h-10 w-24" />
-          </div>
-          <Skeleton className="h-[600px] w-full" />
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-10 w-1/4" />
+          <Skeleton className="h-10 w-1/3" />
+        </div>
+        <Skeleton className="h-[600px] w-full" />
       </div>
     );
   }
 
   return (
     <div className="h-full">
-        <SupervisionTable
-            documents={documents}
-            title="Gestión de Documentos"
-            description="Visualice, busque y gestione todos los documentos de la plataforma."
-        />
+      <DocumentsTable
+        documents={documents}
+        title="Gestión de Documentos"
+        description="Visualice, busque y gestione todos los documentos de la plataforma."
+        searchTerm={searchInput}
+        onSearchChange={setSearchInput}
+        statusFilter={statusFilter}
+        onStatusFilterChange={(s) => {
+          setStatusFilter(s);
+          setPage(1);
+        }}
+        sortOrder={sortOrder}
+        onSortOrderChange={(o) => {
+          setSortOrder(o);
+          setPage(1);
+        }}
+        onAsignadosClick={handleAsignadosClick}
+        statusCounts={counts}
+        dataSource="supervision"
+      />
+      <div className="flex items-center justify-between mt-4">
+        <Button
+          variant="ghost"
+          disabled={page <= 1}
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+        >
+          Anterior
+        </Button>
+        <span className="text-sm text-muted-foreground">
+          Página {page} de {meta?.totalPages ?? 1}
+        </span>
+        <Button
+          variant="ghost"
+          disabled={page >= (meta?.totalPages ?? 1)}
+          onClick={() => setPage((p) => p + 1)}
+        >
+          Siguiente
+        </Button>
+      </div>
+      <SignersModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        firmantes={firmantes}
+        loading={modalLoading}
+      />
     </div>
   );
 }

--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -11,15 +11,8 @@ import {
   type AsignacionDTO,
 } from "@/services/documentsService";
 import { getMe } from "@/services/usersService";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
-import {
-  initialsFromUser,
-  fullName,
-  subtitleFromUser,
-} from "@/lib/avatar";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { SignersModal } from "@/components/signers-modal";
 
 function toUiDocument(a: AsignacionDTO): Document {
   const cf = a.cuadro_firma;
@@ -162,40 +155,12 @@ export default function MisDocumentosPage() {
           Siguiente
         </Button>
       </div>
-      <Dialog open={modalOpen} onOpenChange={setModalOpen}>
-        <DialogContent className="sm:max-w-[425px] glassmorphism" aria-describedby={undefined}>
-          <DialogHeader>
-            <DialogTitle>Firmantes Asignados ({firmantes.length})</DialogTitle>
-          </DialogHeader>
-          <ul className="space-y-4 py-4 max-h-[60vh] overflow-y-auto">
-            {modalLoading ? (
-              <li className="text-sm text-muted-foreground">Cargando firmantes...</li>
-            ) : (
-              firmantes.map((f, idx) => (
-                <li
-                  key={`${f.user.id}-${f.responsabilidad_firma.id}-${idx}`}
-                  className="flex items-center gap-4"
-                >
-                  <Avatar>
-                    <AvatarFallback>{initialsFromUser(f.user)}</AvatarFallback>
-                  </Avatar>
-                  <div className="flex flex-col">
-                    <span className="font-medium">
-                      {fullName(f.user) || f.user.correo_institucional}
-                    </span>
-                    <span className="text-sm text-muted-foreground">
-                      {subtitleFromUser(f.user)}
-                    </span>
-                  </div>
-                  <Badge variant="outline" className="ml-auto">
-                    {f.responsabilidad_firma?.nombre ?? '—'}
-                  </Badge>
-                </li>
-              ))
-            )}
-          </ul>
-        </DialogContent>
-      </Dialog>
+      <SignersModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        firmantes={firmantes}
+        loading={modalLoading}
+      />
     </div>
   );
 }

--- a/src/app/admin/supervision/page.tsx
+++ b/src/app/admin/supervision/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { SupervisionTable } from "@/components/supervision-table";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getDocumentSupervision, type SupervisionDoc } from '@/services/documentsService';
+import { getDocumentSupervision, type DocumentoRow, type SupervisionDoc, type DocEstado } from '@/services/documentsService';
 
 export default function SupervisionPage() {
     const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
@@ -14,8 +14,20 @@ export default function SupervisionPage() {
     useEffect(() => {
         const fetchData = async () => {
             try {
-                const { items } = await getDocumentSupervision();
-                setDocuments(Array.isArray(items) ? items : []);
+                const { documentos } = await getDocumentSupervision();
+                const mapped: SupervisionDoc[] = (documentos ?? []).map((d: DocumentoRow) => ({
+                    id: d.id,
+                    titulo: d.titulo,
+                    descripcion: d.descripcion,
+                    codigo: undefined,
+                    version: undefined,
+                    addDate: d.add_date,
+                    estado: d.estado?.nombre as DocEstado,
+                    empresa: d.empresa,
+                    diasTranscurridos: d.diasTranscurridos,
+                    descripcionEstado: d.descripcionEstado,
+                }));
+                setDocuments(mapped);
             } catch (error) {
                 toast({
                     variant: 'destructive',

--- a/src/components/documents-table.tsx
+++ b/src/components/documents-table.tsx
@@ -37,6 +37,8 @@ interface DocumentsTableProps {
   sortOrder: "asc" | "desc";
   onSortOrderChange: (value: "asc" | "desc") => void;
   onAsignadosClick?: (doc: Document) => void;
+  statusCounts?: Record<Document["status"] | "Todos", number>;
+  dataSource?: "byUser" | "supervision";
 }
 
 const getStatusClass = (status: Document["status"]): string => {
@@ -111,6 +113,8 @@ export function DocumentsTable({
   sortOrder,
   onSortOrderChange,
   onAsignadosClick,
+  statusCounts,
+  dataSource = "byUser",
 }: DocumentsTableProps) {
   const router = useRouter();
 
@@ -160,6 +164,11 @@ export function DocumentsTable({
               variant="outline"
             >
               {status}
+              {statusCounts && (
+                <span className="ml-2 text-xs opacity-75">
+                  ({statusCounts[status] ?? 0})
+                </span>
+              )}
             </Button>
           ))}
         </div>

--- a/src/components/signers-modal.tsx
+++ b/src/components/signers-modal.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { initialsFromUser, fullName, subtitleFromUser } from "@/lib/avatar";
+import type { SignerSummary } from "@/services/documentsService";
+
+interface SignersModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  firmantes: SignerSummary[];
+  loading: boolean;
+}
+
+export function SignersModal({ open, onOpenChange, firmantes, loading }: SignersModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px] glassmorphism" aria-describedby="signers-desc">
+        <DialogHeader>
+          <DialogTitle>Firmantes Asignados ({firmantes.length})</DialogTitle>
+          <DialogDescription id="signers-desc">
+            Personas asignadas a este documento
+          </DialogDescription>
+        </DialogHeader>
+        <ul className="space-y-4 py-4 max-h-[60vh] overflow-y-auto">
+          {loading ? (
+            <li className="text-sm text-muted-foreground">Cargando firmantes...</li>
+          ) : (
+            firmantes.map((f) => (
+              <li
+                key={`${f.user.id}-${f.responsabilidad_firma.id}`}
+                className="flex items-center gap-4"
+              >
+                <Avatar>
+                  <AvatarFallback>{initialsFromUser(f.user)}</AvatarFallback>
+                </Avatar>
+                <div className="flex flex-col">
+                  <span className="font-medium">
+                    {fullName(f.user) || f.user.correo_institucional}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {subtitleFromUser(f.user)}
+                  </span>
+                </div>
+                <div className="ml-auto flex gap-2">
+                  <Badge variant="outline">
+                    {f.responsabilidad_firma?.nombre ?? "—"}
+                  </Badge>
+                  <Badge variant={f.estaFirmado ? "default" : "secondary"}>
+                    {f.estaFirmado ? "Firmado" : "Pendiente"}
+                  </Badge>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export default SignersModal;


### PR DESCRIPTION
## Summary
- extend supervision document service to return full document rows with signer summaries
- generalize documents table with filter counts and shared signers modal
- revamp `/admin/documentos` to use DocumentsTable with pagination, sorting, filters and signer details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c6a171eb6c83328610174f1bc20078