### PR TITLE
Add catalog-driven user selects and role multi-select

### DIFF
--- a/src/components/users-table.tsx
+++ b/src/components/users-table.tsx
@@ -11,6 +11,7 @@ import { User } from '@/lib/data';
 import { UserFormModal } from './user-form-modal';
 import { useToast } from '@/hooks/use-toast';
 import { Avatar, AvatarFallback, AvatarImage } from './ui/avatar';
+import { Badge } from './ui/badge';
 import { UserPasswordDialog } from './user-password-dialog';
 import { useSession } from '@/lib/session';
 
@@ -147,9 +148,32 @@ export function UsersTable({ users, onSaveUser, onDeleteUser }: UsersTableProps)
                       <AvatarFallback>{getInitials(user)}</AvatarFallback>
                     </Avatar>
                   </TableCell>
-                  <TableCell className="font-medium">{getFullName(user)}</TableCell>
-                  <TableCell className="hidden md:table-cell">{user.posicionId}</TableCell>
-                  <TableCell className="hidden lg:table-cell">{user.gerenciaId}</TableCell>
+                  <TableCell className="font-medium">
+                    <div>{getFullName(user)}</div>
+                    {Array.isArray(user.roles) && user.roles.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {user.roles.map((role) => (
+                          <Badge key={`${user.id}-role-${role.id}`} variant="secondary" className="text-xs">
+                            {role.nombre}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    {user.posicionNombre?.trim()
+                      ? user.posicionNombre
+                      : user.posicionId != null && String(user.posicionId).trim() !== ''
+                      ? String(user.posicionId)
+                      : '—'}
+                  </TableCell>
+                  <TableCell className="hidden lg:table-cell">
+                    {user.gerenciaNombre?.trim()
+                      ? user.gerenciaNombre
+                      : user.gerenciaId != null && String(user.gerenciaId).trim() !== ''
+                      ? String(user.gerenciaId)
+                      : '—'}
+                  </TableCell>
                   <TableCell className="hidden md:table-cell">{user.codigoEmpleado}</TableCell>
                   <TableCell className="hidden xl:table-cell">{user.telefono}</TableCell>
                   <TableCell className="hidden xl:table-cell">{user.correoInstitucional}</TableCell>

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,6 +1,5 @@
 export * from "./authService";
 export * from "./usersService";
-export * from "./rolesService";
 export * from "./pagesService";
 export * from "./documentsService";
 export * from "./aiService";


### PR DESCRIPTION
## Summary
- add catalog helpers and extend the user mapper so position/gerencia names, roles, and avatar URLs are available in UI data
- update the user modal to load catalog options, replace position/gerencia text inputs with selects, and submit selected role IDs as a JSON string in FormData
- show catalog names with fallbacks and role badges in the users table while aligning shared user/type definitions

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies cannot be installed in this environment)*
- npm run typecheck *(fails: missing @types/formidable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4532e05c8332978872ad3eaad5fa