### PR TITLE
Normaliza nombres de posición y gerencia en usuarios

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -74,12 +74,12 @@ function mapUserFromApi(u: any): UiUser {
     u?.gerenciaId ??
     (typeof u?.gerencia?.id === 'number' ? u.gerencia.id : undefined);
   const posicionNombre =
-    u?.posicion_nombre ??
     u?.posicionNombre ??
+    u?.posicion_nombre ??
     (typeof u?.posicion?.nombre === 'string' ? u.posicion.nombre : undefined);
   const gerenciaNombre =
-    u?.gerencia_nombre ??
     u?.gerenciaNombre ??
+    u?.gerencia_nombre ??
     (typeof u?.gerencia?.nombre === 'string' ? u.gerencia.nombre : undefined);
   const foto = u?.url_foto ?? u?.urlFoto ?? u?.foto_perfil ?? null;
 

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -28,9 +28,11 @@ type ApiUser = {
   posicion_id?: number | null;
   posicion?: ApiCatalogItem | null;
   posicion_nombre?: string | null;
+  posicionNombre?: string | null;
   gerencia_id?: number | null;
   gerencia?: ApiCatalogItem | null;
   gerencia_nombre?: string | null;
+  gerenciaNombre?: string | null;
   telefono?: string | null;
   activo?: boolean | null;
   url_foto?: string | null;
@@ -80,9 +82,15 @@ const toUiUser = (u: ApiUser): UiUser => {
     .join(' ');
 
   const posicionNombre =
-    u.posicion_nombre ?? (u.posicion && typeof u.posicion.nombre === 'string' ? u.posicion.nombre : undefined);
+    u.posicionNombre ??
+    u.posicion_nombre ??
+    (u.posicion && typeof u.posicion.nombre === 'string' ? u.posicion.nombre : null) ??
+    null;
   const gerenciaNombre =
-    u.gerencia_nombre ?? (u.gerencia && typeof u.gerencia.nombre === 'string' ? u.gerencia.nombre : undefined);
+    u.gerenciaNombre ??
+    u.gerencia_nombre ??
+    (u.gerencia && typeof u.gerencia.nombre === 'string' ? u.gerencia.nombre : null) ??
+    null;
 
   return {
     id: String(u.id),
@@ -95,9 +103,9 @@ const toUiUser = (u: ApiUser): UiUser => {
     correoInstitucional: u.correo_institucional ?? '',
     codigoEmpleado: u.codigo_empleado ?? '',
     posicionId: posicionId != null ? Number(posicionId) : null,
-    posicionNombre: posicionNombre ?? null,
+    posicionNombre,
     gerenciaId: gerenciaId != null ? Number(gerenciaId) : null,
-    gerenciaNombre: gerenciaNombre ?? null,
+    gerenciaNombre,
     telefono: u.telefono ?? '',
     activo: u.activo ?? true,
     fotoPerfil: foto ?? undefined,


### PR DESCRIPTION
## Summary
- prioriza los nombres de posición y gerencia camelCase al mapear usuarios desde la API
- amplía el tipo de usuario para reflejar los nuevos nombres normalizados y reutiliza la URL de foto coherente

## Testing
- npm run lint *(fails: missing @eslint/js from registry in this environment)*
- npm run typecheck *(fails: missing @types/formidable from registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb70b0f66083329b2d6d345ef72168