### PR TITLE
Use avatarUrl from /users/me across session

### DIFF
--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -135,7 +135,7 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" className="relative h-10 w-10 rounded-full">
                 <Avatar className="h-10 w-10">
-                  <AvatarImage src={(avatarUrl as string | undefined) ?? (me?.urlFoto as string | undefined)} alt={displayName ?? 'Usuario'} data-ai-hint="person avatar" />
+                  <AvatarImage src={(avatarUrl as string | undefined) ?? (me?.avatarUrl as string | undefined)} alt={displayName ?? 'Usuario'} data-ai-hint="person avatar" />
                   <AvatarFallback>{initials(displayName ?? me?.nombre ?? (userRole ?? ''))}</AvatarFallback>
                 </Avatar>
               </Button>

--- a/src/components/general-header.tsx
+++ b/src/components/general-header.tsx
@@ -19,7 +19,7 @@ import { UserAvatar } from "@/components/avatar/user-avatar";
 export function GeneralHeader() {
   const router = useRouter();
   const pathname = usePathname();
-  const { signOut, me } = useSession();
+  const { signOut, me, avatarUrl } = useSession();
 
   const isDocumentDetailPage = pathname.startsWith("/documento/");
 
@@ -59,7 +59,7 @@ export function GeneralHeader() {
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" className="relative h-10 w-10 rounded-full">
-                <UserAvatar size="sm" url={me?.urlFoto ?? null} name={me?.nombre ?? "Usuario"} />
+                <UserAvatar size="sm" url={avatarUrl ?? me?.avatarUrl ?? null} name={me?.nombre ?? "Usuario"} />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-56">

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -104,8 +104,8 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
   }, [avatarPreview]);
 
   useEffect(() => {
-    setAvatarPreview(me?.urlFoto ?? null);
-  }, [me?.urlFoto]);
+    setAvatarPreview(me?.avatarUrl ?? null);
+  }, [me?.avatarUrl]);
 
   const handleThemeChange = (isDark: boolean) => {
     const newTheme = isDark ? 'dark' : 'light';
@@ -203,7 +203,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
         title: 'Error',
         description: 'No se pudo actualizar la foto de perfil.',
       });
-      setAvatarPreview(me?.urlFoto ?? null);
+      setAvatarPreview(me?.avatarUrl ?? null);
     } finally {
       setIsUpdatingAvatar(false);
       if (event.target) {
@@ -227,7 +227,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
         title: 'Error',
         description: 'No se pudo actualizar la foto de perfil.',
       });
-      setAvatarPreview(me?.urlFoto ?? null);
+      setAvatarPreview(me?.avatarUrl ?? null);
     } finally {
       setIsUpdatingAvatar(false);
       if (profileImageUploadRef.current) {
@@ -258,7 +258,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
         </DialogHeader>
         <div className="grid gap-6 py-4 flex-1 overflow-y-auto pr-6 pl-1 -mr-6">
           <div className="flex items-center gap-4">
-            <UserAvatar size="lg" url={avatarPreview} name={me?.nombre ?? 'Usuario'} />
+            <UserAvatar size="lg" url={avatarPreview ?? me?.avatarUrl ?? null} name={me?.nombre ?? 'Usuario'} />
             <div className="flex-grow space-y-2">
               <Label>Foto de perfil</Label>
               <p className="text-xs text-muted-foreground">
@@ -280,7 +280,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
                   )}
                   Cambiar foto
                 </Button>
-                {(avatarPreview || me?.urlFoto) && (
+                {(avatarPreview || me?.avatarUrl) && (
                   <Button type="button" variant="ghost" onClick={handleAvatarRemove} disabled={isUpdatingAvatar}>
                     {isUpdatingAvatar ? (
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -11,6 +11,10 @@ export function useSession() {
     staleTime: 5 * 60 * 1000,
   })
 
+  const meWithAvatar = data
+    ? { ...data, avatarUrl: data.avatarUrl ?? data.urlFoto ?? null }
+    : data
+
   const signOut = async () => {
     try {
       await api.post('/auth/logout')
@@ -21,19 +25,19 @@ export function useSession() {
   }
 
   return {
-    me: data,
+    me: meWithAvatar,
     isLoading,
     error,
     refresh: refetch,
-    roles: data?.roles ?? [],
-    pages: data?.pages ?? [],
-    signatureUrl: data?.signatureUrl ?? null,
-    hasSignature: data?.hasSignature ?? false,
-    avatarUrl: data?.urlFoto ?? null,
-    email: data?.correo ?? null,
-    displayName: data?.nombre ?? null,
-    isAdmin: !!data?.roles?.includes('ADMIN'),
-    isSupervisor: !!data?.roles?.includes('SUPERVISOR'),
+    roles: meWithAvatar?.roles ?? [],
+    pages: meWithAvatar?.pages ?? [],
+    signatureUrl: meWithAvatar?.signatureUrl ?? null,
+    hasSignature: meWithAvatar?.hasSignature ?? false,
+    avatarUrl: meWithAvatar?.avatarUrl ?? null,
+    email: meWithAvatar?.correo ?? null,
+    displayName: meWithAvatar?.nombre ?? null,
+    isAdmin: !!meWithAvatar?.roles?.includes('ADMIN'),
+    isSupervisor: !!meWithAvatar?.roles?.includes('SUPERVISOR'),
     signOut,
   }
 }

--- a/src/services/usersService.ts
+++ b/src/services/usersService.ts
@@ -215,10 +215,16 @@ export async function changeUserPassword(
 
 export async function getMe(): Promise<any> {
   const { data } = await api.get('/users/me');
-  const normalized = normalizeOne<any>(data);
-  if (!normalized) return normalized;
-  const urlFoto = normalized.urlFoto ?? normalized.url_foto ?? normalized.foto_perfil ?? null;
-  return { ...normalized, urlFoto };
+  const me = normalizeOne<any>(data);
+  if (!me) return me;
+  const fallbackAvatar =
+    me.avatarUrl ?? me.urlFoto ?? me.url_foto ?? me.foto_perfil ?? null;
+
+  return {
+    ...me,
+    urlFoto: me.urlFoto ?? me.url_foto ?? me.foto_perfil ?? null,
+    avatarUrl: fallbackAvatar,
+  };
 }
 
 export async function updateMyAvatar(file: Blob) {

--- a/src/types/me.ts
+++ b/src/types/me.ts
@@ -16,4 +16,5 @@ export type MeResponseDto = {
   signatureUrl: string | null
   hasSignature: boolean
   urlFoto?: string | null
+  avatarUrl?: string | null
 }


### PR DESCRIPTION
## Summary
- normalize the `/users/me` response to expose avatarUrl alongside existing urlFoto fallback
- ensure useSession consumers receive the normalized avatarUrl data
- update the settings dialog and headers to prefer avatarUrl when rendering avatars

## Testing
- npm run lint
- npm run typecheck *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc5b86904c8332bae01e3cc0b9ac86