### PR TITLE
Show signer avatars across document views

### DIFF
--- a/src/app/admin/documentos/page.tsx
+++ b/src/app/admin/documentos/page.tsx
@@ -29,7 +29,7 @@ function toUiDocument(d: DocumentoRow): Document {
   ).map((f) => ({
     id: String(f.id),
     name: f.nombre,
-    avatar: f.urlFoto ?? undefined,
+    avatar: (f.urlFoto ?? (f as any).avatar ?? null) ?? undefined,
     responsibility: f.responsabilidad,
     department: "",
     employeeCode: "",

--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -27,6 +27,7 @@ function toUiDocument(a: AsignacionDTO): Document {
       : Array.isArray((cf as any).cuadro_firma_user)
       ? (cf as any).cuadro_firma_user.map((f: any) => {
           const u = f.user ?? {};
+          const foto = u.urlFoto ?? u.url_foto ?? null;
           const nombre = [
             u.primer_nombre,
             u.segundo_name,
@@ -40,7 +41,8 @@ function toUiDocument(a: AsignacionDTO): Document {
           return {
             id: Number(u.id ?? f.user_id ?? 0),
             nombre,
-            urlFoto: u.url_foto ?? u.urlFoto ?? u.foto_perfil ?? null,
+            urlFoto: foto,
+            avatar: foto,
             responsabilidad: f.responsabilidad_firma?.nombre ?? "",
           };
         })
@@ -48,7 +50,7 @@ function toUiDocument(a: AsignacionDTO): Document {
   const assignedUsers = srcFirmantes.map((f: any) => ({
     id: String(f.id),
     name: f.nombre,
-    avatar: f.urlFoto ?? undefined,
+    avatar: (f.urlFoto ?? f.avatar ?? null) ?? undefined,
     responsibility: f.responsabilidad,
     department: "",
     employeeCode: "",

--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -49,19 +49,24 @@ export default function DocumentDetailPage() {
     try {
       const det = await getCuadroFirmaDetalle(id, 3600);
       const fs = await getFirmantes(id);
-      const mapped: SignerFull[] = fs.map((f) => ({
-        user: {
-          id: Number(f.user.id),
-          nombre: fullName(f.user),
-          posicion: f.user.posicion?.nombre ?? undefined,
-          gerencia: f.user.gerencia?.nombre ?? undefined,
-        },
+      const mapped: SignerFull[] = fs.map((f) => {
+        const foto = f.user.urlFoto ?? f.user.url_foto ?? f.user.avatar ?? null;
+        return {
+          user: {
+            id: Number(f.user.id),
+            nombre: fullName(f.user),
+            posicion: f.user.posicion?.nombre ?? undefined,
+            gerencia: f.user.gerencia?.nombre ?? undefined,
+            urlFoto: foto ?? undefined,
+            avatar: foto ?? undefined,
+          },
         responsabilidad: {
           id: Number(f.responsabilidad_firma.id),
           nombre: f.responsabilidad_firma.nombre,
         },
         estaFirmado: f.estaFirmado,
-      }));
+        } satisfies SignerFull;
+      });
       setDetalle(det);
       setFirmantes(mapped);
     } catch (e) {
@@ -111,15 +116,20 @@ export default function DocumentDetailPage() {
   const progress = firmantes.length
     ? (firmantes.filter((f) => f.estaFirmado).length / firmantes.length) * 100
     : 0;
-  const signersPanel: Signer[] = firmantes.map((f) => ({
-    id: f.user.id,
-    nombre: f.user.nombre,
-    iniciales: initials(f.user.nombre),
-    responsabilidad: f.responsabilidad.nombre,
-    puesto: f.user.posicion,
-    gerencia: f.user.gerencia,
-    estaFirmado: f.estaFirmado,
-  }));
+  const signersPanel: Signer[] = firmantes.map((f) => {
+    const foto = f.user.urlFoto ?? f.user.avatar ?? null;
+    return {
+      id: f.user.id,
+      nombre: f.user.nombre,
+      iniciales: initials(f.user.nombre),
+      responsabilidad: f.responsabilidad.nombre,
+      puesto: f.user.posicion,
+      gerencia: f.user.gerencia,
+      estaFirmado: f.estaFirmado,
+      urlFoto: foto,
+      avatar: foto,
+    } satisfies Signer;
+  });
 
   const orderResponsabilidad = (nombre: string) => {
     const n = nombre.toLowerCase();

--- a/src/components/document-detail/signers-panel.tsx
+++ b/src/components/document-detail/signers-panel.tsx
@@ -25,7 +25,10 @@ export function SignersPanel({ firmantes, progress }: { firmantes: Signer[]; pro
           <li key={`${f.id}-${f.responsabilidad}`} className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <Avatar className="h-9 w-9">
-                <AvatarImage src={undefined} />
+                <AvatarImage
+                  src={f.urlFoto ?? f.avatar ?? undefined}
+                  alt={f.nombre}
+                />
                 <AvatarFallback>{f.iniciales}</AvatarFallback>
               </Avatar>
               <div className="text-sm">

--- a/src/components/sign-dialog.tsx
+++ b/src/components/sign-dialog.tsx
@@ -170,7 +170,10 @@ export function SignDialog({
                   <li key={`${f.user.id}-${f.responsabilidad.id}`} className="flex items-center justify-between">
                     <div className="flex items-center gap-2">
                       <Avatar className="h-8 w-8">
-                        <AvatarImage src={undefined} />
+                        <AvatarImage
+                          src={f.user.urlFoto ?? f.user.avatar ?? undefined}
+                          alt={f.user.nombre}
+                        />
                         <AvatarFallback>{initials(f.user.nombre)}</AvatarFallback>
                       </Avatar>
                       <div className="text-sm">

--- a/src/components/signers-modal.tsx
+++ b/src/components/signers-modal.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
-import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { initialsFromUser, fullName, subtitleFromUser } from "@/lib/avatar";
 import type { SignerSummary } from "@/services/documentsService";
@@ -34,6 +34,10 @@ export function SignersModal({ open, onOpenChange, firmantes, loading }: Signers
                 className="flex items-center gap-4"
               >
                 <Avatar>
+                  <AvatarImage
+                    src={f.user.urlFoto ?? f.user.url_foto ?? f.user.avatar ?? undefined}
+                    alt={fullName(f.user) || f.user.correo_institucional}
+                  />
                   <AvatarFallback>{initialsFromUser(f.user)}</AvatarFallback>
                 </Avatar>
                 <div className="flex flex-col">

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -81,7 +81,7 @@ function mapUserFromApi(u: any): UiUser {
     u?.gerenciaNombre ??
     u?.gerencia_nombre ??
     (typeof u?.gerencia?.nombre === 'string' ? u.gerencia.nombre : undefined);
-  const foto = u?.url_foto ?? u?.urlFoto ?? u?.foto_perfil ?? null;
+  const foto = u?.urlFoto ?? u?.url_foto ?? u?.foto_perfil ?? null;
 
   const roles = Array.isArray(u?.roles)
     ? u.roles

--- a/src/services/documentsService.ts
+++ b/src/services/documentsService.ts
@@ -30,6 +30,7 @@ export type DocumentoRow = {
     nombre: string;
     iniciales: string;
     urlFoto: string | null;
+    avatar?: string | null;
     responsabilidad: string;
   }>;
 };
@@ -65,6 +66,8 @@ export type Signer = {
   gerencia?: string | null;
   estaFirmado: boolean;
   diasTranscurridos?: number;
+  urlFoto?: string | null;
+  avatar?: string | null;
 };
 
 export type DocumentDetail = {
@@ -94,6 +97,10 @@ export type SignerSummary = {
     codigo_empleado?: string | null;
     posicion?: { nombre?: string | null } | null;
     gerencia?: { nombre?: string | null } | null;
+    url_foto?: string | null;
+    urlFoto?: string | null;
+    avatar?: string | null;
+    foto_perfil?: string | null;
   };
   responsabilidad_firma: { id: number; nombre: string };
 };
@@ -106,7 +113,14 @@ export type SignerPending = {
 };
 
 export type SignerFull = {
-  user: { id: number; nombre: string; posicion?: string; gerencia?: string };
+  user: {
+    id: number;
+    nombre: string;
+    posicion?: string;
+    gerencia?: string;
+    urlFoto?: string | null;
+    avatar?: string | null;
+  };
   responsabilidad: { id: number; nombre: string };
   estaFirmado: boolean;
 };
@@ -136,12 +150,16 @@ const toDocumentoRow = (d: any): DocumentoRow => {
         id: Number(f.id ?? 0),
         nombre: f.nombre ?? '',
         iniciales: f.iniciales ?? initials(f.nombre ?? ''),
-        urlFoto: f.urlFoto ?? null,
+        ...(() => {
+          const foto = f.urlFoto ?? f.avatar ?? null;
+          return { urlFoto: foto, avatar: foto };
+        })(),
         responsabilidad: f.responsabilidad ?? '',
       }))
     : Array.isArray(x.cuadro_firma_user)
     ? x.cuadro_firma_user.map((f: any) => {
         const u = f.user ?? {};
+        const foto = u.urlFoto ?? u.url_foto ?? u.foto_perfil ?? null;
         const nombre = [
           u.primer_nombre,
           u.segundo_name,
@@ -156,7 +174,8 @@ const toDocumentoRow = (d: any): DocumentoRow => {
           id: Number(u.id ?? f.user_id ?? 0),
           nombre,
           iniciales: initials(nombre ?? ''),
-          urlFoto: u.url_foto ?? u.urlFoto ?? u.foto_perfil ?? null,
+          urlFoto: foto,
+          avatar: foto,
           responsabilidad: f.responsabilidad_firma?.nombre ?? '',
         };
       })
@@ -305,6 +324,7 @@ export async function getDocumentDetail(id: number): Promise<DocumentDetail> {
   const firmantes: Signer[] = Array.isArray(x.cuadro_firma_user)
     ? x.cuadro_firma_user.map((f: any) => {
         const u = f.user ?? {};
+        const foto = u.urlFoto ?? u.url_foto ?? u.foto_perfil ?? null;
         return {
           id: Number(u.id ?? 0),
           nombre: fullName(u),
@@ -321,6 +341,8 @@ export async function getDocumentDetail(id: number): Promise<DocumentDetail> {
           gerencia: u.gerencia?.nombre ?? null,
           estaFirmado: Boolean(f.estaFirmado),
           diasTranscurridos: f.diasTranscurridos ?? undefined,
+          urlFoto: foto,
+          avatar: foto,
         } as Signer;
       })
     : [];


### PR DESCRIPTION
## Summary
- propagate signer photo URLs through document fetchers and UI mappers
- render signer avatars with actual images in document detail sidebar, signer modal, and sign dialog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc65cbd2ac83329e3ff7aaffca34c6