### PR TITLE
Fix pagination type safety and legacy fallbacks

### DIFF
--- a/src/app/admin/asignaciones/page.tsx
+++ b/src/app/admin/asignaciones/page.tsx
@@ -57,9 +57,8 @@ export default function AsignacionesPage() {
     let mounted = true;
     (async () => {
       try {
-        const data = await getUsers();
-        const list = Array.isArray(data) ? data : [];
-        if (mounted) setUsers(list);
+        const { items } = await getUsers({ page: 1, limit: 200, includeInactive: true });
+        if (mounted) setUsers(items);
       } catch (err) {
         console.error(err);
         toast({

--- a/src/app/admin/permission/page.tsx
+++ b/src/app/admin/permission/page.tsx
@@ -24,7 +24,10 @@ export default function PermissionPage() {
   useEffect(() => {
     const loadBase = async () => {
       try {
-        const [rolesData, pagesData] = await Promise.all([getRoles(), getPages(false)]);
+        const [{ items: rolesData }, { items: pagesData }] = await Promise.all([
+          getRoles({ page: 1, limit: 100, showInactive: true }),
+          getPages({ page: 1, limit: 200, showInactive: true }),
+        ]);
         setRoles(rolesData.filter(r => r.activo));
         setPages(pagesData.filter(p => p.activo));
       } catch (error) {
@@ -98,7 +101,7 @@ export default function PermissionPage() {
           </SelectTrigger>
           <SelectContent>
             {roles.map(r => (
-              <SelectItem key={r.id} value={r.id!}>
+              <SelectItem key={r.id} value={String(r.id ?? '')}>
                 {r.nombre}
               </SelectItem>
             ))}

--- a/src/app/admin/supervision/page.tsx
+++ b/src/app/admin/supervision/page.tsx
@@ -1,71 +1,150 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { SupervisionTable } from "@/components/supervision-table";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
-import { getDocumentSupervision, type DocumentoRow, type SupervisionDoc, type DocEstado } from '@/services/documentsService';
+import {
+  getDocumentSupervision,
+  getSupervisionStats,
+  type DocumentoRow,
+  type SupervisionDoc,
+  type DocEstado,
+} from '@/services/documentsService';
+import { useServerPagination } from '@/hooks/useServerPagination';
+
+const toSupervisionDoc = (d: DocumentoRow): SupervisionDoc => {
+  const x = d ?? (d as any)?.cuadro_firma ?? {};
+  return {
+    id: Number(x.id ?? 0),
+    titulo: x.titulo ?? '',
+    descripcion: x.descripcion ?? null,
+    codigo: x.codigo ?? null,
+    version: x.version ?? null,
+    addDate: x.add_date ?? x.addDate ?? null,
+    estado: (x?.estado_firma?.nombre ?? x?.estado?.nombre ?? '') as DocEstado,
+    empresa: x.empresa ?? null,
+    diasTranscurridos: x.diasTranscurridos ?? undefined,
+    descripcionEstado: x.descripcionEstado ?? null,
+  };
+};
+
+const statusCountsDefault: Record<DocEstado | 'Todos', number> = {
+  Todos: 0,
+  Pendiente: 0,
+  'En Progreso': 0,
+  Rechazado: 0,
+  Completado: 0,
+};
 
 export default function SupervisionPage() {
-    const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const { toast } = useToast();
+  const [documents, setDocuments] = useState<SupervisionDoc[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState<DocEstado | 'Todos'>('Todos');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+  const [counts, setCounts] = useState(statusCountsDefault);
+  const { toast } = useToast();
+  const { page, limit, setPage, setLimit, setFromMeta } = useServerPagination();
 
-    useEffect(() => {
-        const fetchData = async () => {
-            try {
-                const { documentos } = await getDocumentSupervision();
-                const mapped: SupervisionDoc[] = (documentos ?? []).map((d: DocumentoRow) => ({
-                    id: d.id,
-                    titulo: d.titulo,
-                    descripcion: d.descripcion,
-                    codigo: undefined,
-                    version: undefined,
-                    addDate: d.add_date,
-                    estado: d.estado?.nombre as DocEstado,
-                    empresa: d.empresa,
-                    diasTranscurridos: d.diasTranscurridos,
-                    descripcionEstado: d.descripcionEstado,
-                }));
-                setDocuments(mapped);
-            } catch (error) {
-                toast({
-                    variant: 'destructive',
-                    title: 'Error al cargar datos',
-                    description: 'No se pudieron obtener los datos para la supervisión.',
-                });
-            } finally {
-                setIsLoading(false);
-            }
-        };
-        fetchData();
-    }, [toast]);
-    const supervisionDocuments = documents;
-    if (isLoading) {
-        return (
-            <div className="space-y-4">
-                <div className="flex justify-between items-center">
-                    <Skeleton className="h-10 w-1/4" />
-                    <Skeleton className="h-10 w-1/3" />
-                </div>
-                 <div className="flex gap-2">
-                    <Skeleton className="h-10 w-24" />
-                    <Skeleton className="h-10 w-24" />
-                    <Skeleton className="h-10 w-24" />
-                    <Skeleton className="h-10 w-24" />
-                 </div>
-                <Skeleton className="h-[600px] w-full" />
-            </div>
-        );
+  useEffect(() => {
+    const handler = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(handler);
+  }, [searchInput]);
+
+  const fetchDocuments = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const params: Record<string, any> = { page, limit, sort: sortOrder };
+      if (search) params.search = search;
+      if (statusFilter !== 'Todos') params.estado = statusFilter;
+      const { items, meta } = await getDocumentSupervision(params);
+      setTotal(meta.total ?? 0);
+      if (meta.pages > 0 && page > meta.pages) {
+        setFromMeta(meta);
+        return;
+      }
+      setDocuments(items.map(toSupervisionDoc));
+      setFromMeta(meta);
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: 'Error al cargar datos',
+        description: 'No se pudieron obtener los datos para la supervisión.',
+      });
+    } finally {
+      setIsLoading(false);
     }
+  }, [limit, page, search, statusFilter, sortOrder, setFromMeta, toast]);
 
+  useEffect(() => {
+    fetchDocuments();
+  }, [fetchDocuments]);
+
+  useEffect(() => {
+    const loadCounts = async () => {
+      try {
+        const resumen = await getSupervisionStats({ search });
+        setCounts({
+          Todos: resumen.Todos ?? 0,
+          Pendiente: resumen.Pendiente ?? 0,
+          'En Progreso': resumen['En Progreso'] ?? 0,
+          Rechazado: resumen.Rechazado ?? 0,
+          Completado: resumen.Completado ?? 0,
+        });
+      } catch {
+        setCounts(statusCountsDefault);
+      }
+    };
+    loadCounts();
+  }, [search]);
+
+  if (isLoading) {
     return (
-      <div className="h-full">
-          <SupervisionTable
-              documents={supervisionDocuments}
-              title="Supervisión de Documentos"
-              description="Monitoree el estado y progreso de todos los documentos en tiempo real."
-          />
+      <div className="space-y-4">
+        <div className="flex justify-between items-center">
+          <Skeleton className="h-10 w-1/4" />
+          <Skeleton className="h-10 w-1/3" />
+        </div>
+        <div className="flex gap-2">
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-24" />
+          <Skeleton className="h-10 w-24" />
+        </div>
+        <Skeleton className="h-[600px] w-full" />
       </div>
     );
   }
+
+  return (
+    <div className="h-full">
+      <SupervisionTable
+        documents={documents}
+        title="Supervisión de Documentos"
+        description="Monitoree el estado y progreso de todos los documentos en tiempo real."
+        searchTerm={searchInput}
+        onSearchChange={setSearchInput}
+        statusFilter={statusFilter}
+        onStatusFilterChange={(s) => {
+          setStatusFilter(s);
+          setPage(1);
+        }}
+        sortOrder={sortOrder}
+        onSortOrderChange={(order) => {
+          setSortOrder(order);
+          setPage(1);
+        }}
+        statusCounts={counts}
+        total={total}
+        page={page}
+        pageSize={limit}
+        onPageChange={setPage}
+        onPageSizeChange={setLimit}
+      />
+    </div>
+  );
+}
+

--- a/src/components/documents-table.tsx
+++ b/src/components/documents-table.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "./ui/button";
 import { useRouter } from "next/navigation";
 import { initialsFromUser } from "@/lib/avatar";
+import { PaginationBar } from "./pagination/PaginationBar";
 
 interface DocumentsTableProps {
   documents: Document[];
@@ -39,6 +40,11 @@ interface DocumentsTableProps {
   onAsignadosClick?: (doc: Document) => void;
   statusCounts?: Record<Document["status"] | "Todos", number>;
   dataSource?: "byUser" | "supervision";
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
 }
 
 const getStatusClass = (status: Document["status"]): string => {
@@ -115,6 +121,11 @@ export function DocumentsTable({
   onAsignadosClick,
   statusCounts,
   dataSource = "byUser",
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
 }: DocumentsTableProps) {
   const router = useRouter();
 
@@ -237,6 +248,13 @@ export function DocumentsTable({
           </TableBody>
         </Table>
       </CardContent>
+      <PaginationBar
+        total={total}
+        page={page}
+        pageSize={pageSize}
+        onPageChange={onPageChange}
+        onPageSizeChange={onPageSizeChange}
+      />
     </Card>
   );
 }

--- a/src/components/pages-table.tsx
+++ b/src/components/pages-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
@@ -12,9 +12,17 @@ import { Badge } from '@/components/ui/badge';
 import { PageFormModal, PageForm } from './page-form-modal';
 import type { Page } from '@/services/pageService';
 import { format } from 'date-fns';
+import { PaginationBar } from './pagination/PaginationBar';
 
 interface PagesTableProps {
   pages: Page[];
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
   showInactive: boolean;
   onToggleInactive: (checked: boolean) => void;
   onSavePage: (page: PageForm) => Promise<void>;
@@ -22,15 +30,23 @@ interface PagesTableProps {
   onRestorePage: (id: number) => Promise<void> | void;
 }
 
-export function PagesTable({ pages, showInactive, onToggleInactive, onSavePage, onDeletePage, onRestorePage }: PagesTableProps) {
-  const [searchTerm, setSearchTerm] = useState('');
+export function PagesTable({
+  pages,
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  searchTerm,
+  onSearchChange,
+  showInactive,
+  onToggleInactive,
+  onSavePage,
+  onDeletePage,
+  onRestorePage,
+}: PagesTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPage, setSelectedPage] = useState<Page | undefined>(undefined);
-
-  const filteredPages = useMemo(
-    () => pages.filter(p => p.nombre.toLowerCase().includes(searchTerm.toLowerCase())),
-    [pages, searchTerm]
-  );
 
   const openModal = (page?: Page) => {
     setSelectedPage(page);
@@ -53,7 +69,7 @@ export function PagesTable({ pages, showInactive, onToggleInactive, onSavePage, 
         <CardHeader>
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
             <div className="space-y-1.5">
-              <CardTitle>Gestión de Páginas ({pages.length})</CardTitle>
+              <CardTitle>Gestión de Páginas ({total})</CardTitle>
               <CardDescription>Administre las páginas de la plataforma.</CardDescription>
             </div>
             <div className="flex items-center gap-2 flex-wrap justify-end">
@@ -63,7 +79,7 @@ export function PagesTable({ pages, showInactive, onToggleInactive, onSavePage, 
                   placeholder="Buscar páginas..."
                   className="pl-8"
                   value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
+                  onChange={(e) => onSearchChange(e.target.value)}
                 />
               </div>
               <div className="flex items-center space-x-2">
@@ -90,7 +106,7 @@ export function PagesTable({ pages, showInactive, onToggleInactive, onSavePage, 
               </TableRow>
             </TableHeader>
             <TableBody>
-              {filteredPages.map(page => (
+              {pages.map(page => (
                 <TableRow key={page.id}>
                   <TableCell className="font-medium">{page.nombre}</TableCell>
                   <TableCell className="hidden md:table-cell">{page.url}</TableCell>
@@ -135,6 +151,13 @@ export function PagesTable({ pages, showInactive, onToggleInactive, onSavePage, 
             </TableBody>
           </Table>
         </CardContent>
+        <PaginationBar
+          total={total}
+          page={page}
+          pageSize={pageSize}
+          onPageChange={onPageChange}
+          onPageSizeChange={onPageSizeChange}
+        />
       </Card>
       <PageFormModal
         isOpen={isModalOpen}

--- a/src/components/pagination/PaginationBar.tsx
+++ b/src/components/pagination/PaginationBar.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useMemo } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+
+const DEFAULT_OPTIONS = [10, 20, 50, 100] as const;
+
+export interface PaginationBarProps {
+  total: number;
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
+  pageSizeOptions?: number[];
+  className?: string;
+}
+
+export function PaginationBar({
+  total,
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = DEFAULT_OPTIONS as unknown as number[],
+  className,
+}: PaginationBarProps) {
+  const size = Number.isFinite(pageSize) && pageSize > 0 ? Math.floor(pageSize) : DEFAULT_OPTIONS[0];
+  const pages = Math.max(1, Math.ceil((Number.isFinite(total) ? Math.max(0, total) : 0) / size) || 1);
+  const currentPage = Math.min(Math.max(1, Math.floor(page || 1)), pages);
+
+  const options = useMemo(() => {
+    const set = new Set<number>();
+    [...pageSizeOptions, size].forEach((value) => {
+      if (Number.isFinite(value) && value > 0) set.add(Math.floor(value));
+    });
+    return Array.from(set).sort((a, b) => a - b);
+  }, [pageSizeOptions, size]);
+
+  const handleFirst = () => {
+    if (currentPage > 1) onPageChange(1);
+  };
+  const handlePrev = () => {
+    if (currentPage > 1) onPageChange(currentPage - 1);
+  };
+  const handleNext = () => {
+    if (currentPage < pages) onPageChange(currentPage + 1);
+  };
+  const handleLast = () => {
+    if (currentPage < pages) onPageChange(pages);
+  };
+
+  return (
+    <div
+      className={cn(
+        "border-t px-6 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between",
+        className,
+      )}
+    >
+      <span className="text-sm text-muted-foreground">
+        Página {currentPage} de {pages} — {total ?? 0} registros
+      </span>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
+        <div className="flex items-center gap-2">
+          <span className="text-sm text-muted-foreground">Por página</span>
+          <Select
+            value={String(size)}
+            onValueChange={(value) => {
+              const next = Number(value);
+              if (Number.isFinite(next) && next > 0) onPageSizeChange(Math.floor(next));
+            }}
+          >
+            <SelectTrigger className="w-[120px]" aria-label="Registros por página">
+              <SelectValue placeholder={`${size}`} />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((option) => (
+                <SelectItem key={option} value={String(option)}>
+                  {option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="flex items-center gap-2 self-end sm:self-auto">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleFirst}
+            disabled={currentPage <= 1}
+            aria-label="Primera página"
+          >
+            ⏮︎
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handlePrev}
+            disabled={currentPage <= 1}
+            aria-label="Página anterior"
+          >
+            ⟨ Anterior
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleNext}
+            disabled={currentPage >= pages}
+            aria-label="Página siguiente"
+          >
+            Siguiente ⟩
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleLast}
+            disabled={currentPage >= pages}
+            aria-label="Última página"
+          >
+            ⏭︎
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/role-form-modal.tsx
+++ b/src/components/role-form-modal.tsx
@@ -26,13 +26,17 @@ import {
 import { Loader2 } from "lucide-react";
 import type { Role } from "@/services/roleService";
 
-export type RoleForm = Pick<Role, "id" | "nombre" | "descripcion">;
+export type RoleForm = {
+  id?: string;
+  nombre: string;
+  descripcion?: string;
+};
 
 interface RoleFormModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (role: RoleForm) => Promise<void> | void;
-  role?: RoleForm;
+  role?: Role | null;
 }
 
 const formSchema = z.object({
@@ -46,13 +50,20 @@ const defaultValues: RoleForm = { nombre: "", descripcion: "" };
 export function RoleFormModal({ isOpen, onClose, onSave, role }: RoleFormModalProps) {
   const form = useForm<RoleForm>({
     resolver: zodResolver(formSchema),
-    defaultValues: role ?? defaultValues,
+    defaultValues,
   });
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     if (isOpen) {
-      form.reset(role ?? defaultValues);
+      const values: RoleForm = role
+        ? {
+            id: role.id != null ? String(role.id) : undefined,
+            nombre: role.nombre ?? "",
+            descripcion: role.descripcion ?? "",
+          }
+        : { ...defaultValues };
+      form.reset(values);
     }
   }, [isOpen, role, form]);
 

--- a/src/hooks/useServerPagination.ts
+++ b/src/hooks/useServerPagination.ts
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import type { PaginationMeta } from "@/lib/pagination";
+
+type MetaLike =
+  | PaginationMeta
+  | (Partial<{
+      page: number;
+      currentPage: number;
+      pageIndex: number;
+      limit: number;
+      perPage: number;
+      pageSize: number;
+      itemsPerPage: number;
+      pages: number;
+      totalPages: number;
+      lastPage: number;
+      pageCount: number;
+    }> &
+      Record<string, unknown>);
+
+const DEFAULT_LIMIT = 10;
+
+const parseParam = (value: string | null | undefined, fallback: number): number => {
+  if (value == null) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+};
+
+const clampPage = (page: number) => {
+  if (!Number.isFinite(page) || page <= 0) return 1;
+  return Math.floor(page);
+};
+
+const pickMetaNumber = (meta: MetaLike | undefined, keys: string[]): number | undefined => {
+  if (!meta) return undefined;
+  const record = meta as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record?.[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return undefined;
+};
+
+export const useServerPagination = (defaults: { page?: number; limit?: number } = {}) => {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const initialPage = clampPage(parseParam(searchParams?.get("page"), defaults.page ?? 1));
+  const initialLimit = parseParam(searchParams?.get("limit"), defaults.limit ?? DEFAULT_LIMIT);
+
+  const [state, setState] = useState({ page: initialPage, limit: initialLimit });
+
+  const storageKey = useMemo(() => `pagination:${pathname}`, [pathname]);
+
+  const updateUrl = useCallback(
+    (nextPage: number, nextLimit: number, options?: { replace?: boolean }) => {
+      const params = new URLSearchParams(searchParams?.toString() ?? "");
+      params.set("page", String(nextPage));
+      params.set("limit", String(nextLimit));
+      const query = params.toString();
+      const url = query ? `${pathname}?${query}` : pathname;
+      const method = options?.replace ? router.replace : router.push;
+      method(url, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
+  useEffect(() => {
+    const pageParam = searchParams?.get("page");
+    const limitParam = searchParams?.get("limit");
+    setState((prev) => {
+      const nextPage = clampPage(parseParam(pageParam, prev.page));
+      const nextLimit = parseParam(limitParam, prev.limit);
+      if (nextPage === prev.page && nextLimit === prev.limit) return prev;
+      return { page: nextPage, limit: nextLimit };
+    });
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (searchParams?.has("limit")) return;
+    try {
+      const stored = window.localStorage.getItem(storageKey);
+      if (!stored) return;
+      const parsed = JSON.parse(stored) as { limit?: unknown } | null;
+      const storedLimit = parseParam(
+        parsed && typeof parsed.limit !== "string" ? String(parsed.limit ?? "") : (parsed?.limit as string | undefined),
+        state.limit,
+      );
+      if (!storedLimit || storedLimit === state.limit) return;
+      setState((prev) => {
+        if (prev.limit === storedLimit) return prev;
+        updateUrl(prev.page, storedLimit, { replace: true });
+        return { page: prev.page, limit: storedLimit };
+      });
+    } catch {
+      /* ignore storage errors */
+    }
+  }, [searchParams, state.limit, storageKey, updateUrl]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify({ limit: state.limit }));
+    } catch {
+      /* ignore storage errors */
+    }
+  }, [state.limit, storageKey]);
+
+  const setPage = useCallback(
+    (nextPage: number) => {
+      setState((prev) => {
+        const pageValue = clampPage(nextPage);
+        if (pageValue === prev.page) return prev;
+        updateUrl(pageValue, prev.limit);
+        return { ...prev, page: pageValue };
+      });
+    },
+    [updateUrl],
+  );
+
+  const setLimit = useCallback(
+    (nextLimit: number) => {
+      setState((prev) => {
+        const limitValue = parseParam(String(nextLimit), DEFAULT_LIMIT);
+        if (limitValue === prev.limit && prev.page === 1) return prev;
+        updateUrl(1, limitValue);
+        return { page: 1, limit: limitValue };
+      });
+    },
+    [updateUrl],
+  );
+
+  const setFromMeta = useCallback(
+    (meta?: MetaLike | null) => {
+      if (!meta) return;
+      setState((prev) => {
+        const metaLimit = pickMetaNumber(meta, ["limit", "perPage", "pageSize", "itemsPerPage"]);
+        const metaPage = pickMetaNumber(meta, ["page", "currentPage", "pageIndex"]);
+        const metaPages = pickMetaNumber(meta, ["pages", "totalPages", "lastPage", "pageCount"]);
+
+        let nextLimit = prev.limit;
+        if (metaLimit && metaLimit > 0) nextLimit = Math.floor(metaLimit);
+
+        let nextPage = prev.page;
+        if (metaPage && metaPage > 0) nextPage = Math.floor(metaPage);
+        if (metaPages && metaPages > 0 && nextPage > metaPages) nextPage = Math.floor(metaPages);
+        if (nextPage <= 0) nextPage = 1;
+
+        if (nextPage === prev.page && nextLimit === prev.limit) return prev;
+        updateUrl(nextPage, nextLimit, { replace: true });
+        return { page: nextPage, limit: nextLimit };
+      });
+    },
+    [updateUrl],
+  );
+
+  const params = useMemo(() => ({ page: state.page, limit: state.limit }), [state.page, state.limit]);
+
+  return {
+    page: state.page,
+    limit: state.limit,
+    setPage,
+    setLimit,
+    params,
+    setFromMeta,
+  } as const;
+};
+

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -85,16 +85,17 @@ function mapUserFromApi(u: any): UiUser {
 
   const roles = Array.isArray(u?.roles)
     ? u.roles
-        .map((r: any) => ({
-          id: typeof r?.id === 'number' ? r.id : Number(r?.id),
-          nombre:
+        .map((r: any): { id: number; nombre: string } => {
+          const id = typeof r?.id === 'number' ? r.id : Number(r?.id);
+          const nombre =
             typeof r?.nombre === 'string'
               ? r.nombre
               : typeof r?.name === 'string'
               ? r.name
-              : '',
-        }))
-        .filter((r) => Number.isFinite(r.id) && r.nombre.trim() !== '')
+              : '';
+          return { id, nombre };
+        })
+        .filter((r: { id: number; nombre: string }) => Number.isFinite(r.id) && r.nombre.trim() !== '')
     : [];
 
   const user: UiUser = {

--- a/src/lib/pagination.ts
+++ b/src/lib/pagination.ts
@@ -1,0 +1,126 @@
+export interface PaginationMeta {
+  total: number;
+  page: number;
+  limit: number;
+  pages: number;
+  lastPage: number;
+  hasNextPage: boolean;
+  hasPrevPage: boolean;
+}
+
+export interface PaginatedResult<T> {
+  items: T[];
+  meta: PaginationMeta;
+}
+
+const META_NUMBER_KEYS = [
+  'total',
+  'totalCount',
+  'count',
+  'totalItems',
+  'itemCount',
+  'limit',
+  'perPage',
+  'pageSize',
+  'itemsPerPage',
+  'page',
+  'currentPage',
+  'pageIndex',
+  'pages',
+  'totalPages',
+  'lastPage',
+  'pageCount',
+];
+
+const DEFAULT_LIMIT = 10;
+
+export const hasPaginationMeta = (meta: unknown): meta is Record<string, unknown> => {
+  if (!meta || typeof meta !== 'object') return false;
+  return META_NUMBER_KEYS.some((key) => {
+    const value = (meta as Record<string, unknown>)[key];
+    return typeof value === 'number' && Number.isFinite(value);
+  });
+};
+
+const toPositiveInteger = (value: unknown, fallback: number): number => {
+  const num = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+  if (!Number.isFinite(num) || num <= 0) return fallback;
+  return Math.floor(num);
+};
+
+const clampPage = (page: number, pages: number) => {
+  if (pages <= 0) return 1;
+  if (page < 1) return 1;
+  if (page > pages) return pages;
+  return page;
+};
+
+export const normalizePaginationMeta = (
+  meta: Record<string, unknown> | undefined,
+  fallback: { total?: number; page?: number; limit?: number } = {},
+): PaginationMeta => {
+  const rawTotal =
+    meta?.total ??
+    meta?.totalCount ??
+    meta?.count ??
+    meta?.totalItems ??
+    meta?.itemCount ??
+    fallback.total ??
+    0;
+  const rawLimit =
+    meta?.limit ??
+    meta?.perPage ??
+    meta?.pageSize ??
+    meta?.itemsPerPage ??
+    fallback.limit ??
+    DEFAULT_LIMIT;
+  const rawPage = meta?.page ?? meta?.currentPage ?? meta?.pageIndex ?? fallback.page ?? 1;
+  const rawPages =
+    meta?.pages ??
+    meta?.totalPages ??
+    meta?.lastPage ??
+    meta?.pageCount ??
+    (rawLimit ? Math.ceil(Number(rawTotal) / Number(rawLimit)) : undefined);
+
+  const limit = toPositiveInteger(rawLimit, fallback.limit ?? DEFAULT_LIMIT);
+  const total = Math.max(0, Math.floor(Number(rawTotal) || 0));
+  const pages = Math.max(1, toPositiveInteger(rawPages, Math.ceil(total / limit) || 1));
+  const page = clampPage(toPositiveInteger(rawPage, fallback.page ?? 1), pages);
+
+  return {
+    total,
+    page,
+    limit,
+    pages,
+    lastPage: pages,
+    hasNextPage: page < pages,
+    hasPrevPage: page > 1,
+  };
+};
+
+export const paginateArray = <T>(
+  source: T[],
+  options: { page?: number; limit?: number } = {},
+): PaginatedResult<T> => {
+  const limit = toPositiveInteger(options.limit, DEFAULT_LIMIT);
+  const total = source.length;
+  const pages = Math.max(1, Math.ceil(total / limit) || 1);
+  const page = clampPage(toPositiveInteger(options.page, 1), pages);
+  const start = (page - 1) * limit;
+  const end = start + limit;
+  const items = source.slice(start, end);
+
+  return {
+    items,
+    meta: {
+      total,
+      page,
+      limit,
+      pages,
+      lastPage: pages,
+      hasNextPage: page < pages,
+      hasPrevPage: page > 1,
+    },
+  };
+};
+

--- a/src/services/pageService.ts
+++ b/src/services/pageService.ts
@@ -5,10 +5,12 @@ import {
   deletePagina,
   restorePagina,
   type PaginaUI,
+  type GetPagesParams,
 } from "./pagesService";
 import { getRolePages, setRolePages } from "./rolesService";
 
 export type Page = PaginaUI;
+export type { GetPagesParams };
 
 export {
   getPaginas as getPages,

--- a/src/services/pagesService.ts
+++ b/src/services/pagesService.ts
@@ -1,5 +1,6 @@
 import { api } from '@/lib/api';
-import { normalizeList, normalizeOne } from '@/lib/apiEnvelope';
+import { normalizeList, normalizeOne, unwrapPaginated } from '@/lib/apiEnvelope';
+import { hasPaginationMeta, normalizePaginationMeta, paginateArray, type PaginatedResult } from '@/lib/pagination';
 
 export interface PaginaUI {
   id: number;
@@ -9,9 +10,46 @@ export interface PaginaUI {
   createdAt?: string;
   activo?: boolean;
 }
-export async function getPaginas(params?: any): Promise<PaginaUI[]> {
-  const { data } = await api.get('/paginas', { params });
-  return normalizeList<PaginaUI>(data);
+export interface GetPagesParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  showInactive?: boolean;
+  [key: string]: unknown;
+}
+
+const filterPages = (pages: PaginaUI[], search: string, showInactive: boolean) => {
+  const term = search.trim().toLowerCase();
+  return pages
+    .filter((page) => {
+      if (!showInactive && page.activo === false) return false;
+      if (!term) return true;
+      const nombre = (page.nombre ?? '').toLowerCase();
+      const descripcion = (page.descripcion ?? '').toLowerCase();
+      const url = (page.url ?? '').toLowerCase();
+      return nombre.includes(term) || descripcion.includes(term) || url.includes(term);
+    })
+    .sort((a, b) => (a.nombre ?? '').localeCompare(b.nombre ?? ''));
+};
+
+export async function getPaginas(params: GetPagesParams = {}): Promise<PaginatedResult<PaginaUI>> {
+  const { page = 1, limit = 10, search = '', showInactive = false, ...rest } = params;
+  const query: Record<string, unknown> = { ...rest };
+  if (params.page != null) query.page = page;
+  if (params.limit != null) query.limit = limit;
+  if (search.trim() !== '') query.search = search.trim();
+
+  const { data } = await api.get('/paginas', { params: query });
+  const pag = unwrapPaginated<PaginaUI>(data);
+  if (hasPaginationMeta(pag.meta)) {
+    const meta = normalizePaginationMeta(pag.meta, { page, limit });
+    const items = (pag.items.length ? pag.items : normalizeList<PaginaUI>(data)) as PaginaUI[];
+    return { items, meta };
+  }
+
+  const list = normalizeList<PaginaUI>(data);
+  const filtered = filterPages(list, search, showInactive);
+  return paginateArray(filtered, { page, limit });
 }
 
 export async function createPagina(body: any): Promise<PaginaUI> {

--- a/src/services/roleService.ts
+++ b/src/services/roleService.ts
@@ -1,9 +1,2 @@
-export interface Role {
-  id?: string;
-  nombre: string;
-  descripcion?: string;
-  activo?: boolean;
-  createdAt?: string;
-}
-
+export type { Role, GetRolesParams } from "./rolesService";
 export * from "./rolesService";

--- a/src/services/rolesService.ts
+++ b/src/services/rolesService.ts
@@ -1,9 +1,54 @@
 import { api } from '@/lib/api';
-import { normalizeList, normalizeOne } from '@/lib/apiEnvelope';
+import { normalizeList, normalizeOne, unwrapPaginated } from '@/lib/apiEnvelope';
+import { hasPaginationMeta, normalizePaginationMeta, paginateArray, type PaginatedResult } from '@/lib/pagination';
 
-export async function getRoles(params?: { all?: string | number }) {
-  const { data } = await api.get('/roles', { params });
-  return normalizeList<any>(data);
+export interface Role {
+  id?: string | number;
+  nombre: string;
+  descripcion?: string;
+  activo?: boolean;
+  createdAt?: string;
+}
+
+export interface GetRolesParams {
+  page?: number;
+  limit?: number;
+  search?: string;
+  showInactive?: boolean;
+  [key: string]: unknown;
+}
+
+const filterRoles = (roles: Role[], search: string, showInactive: boolean) => {
+  const term = search.trim().toLowerCase();
+  return roles
+    .filter((role) => {
+      if (!showInactive && role.activo === false) return false;
+      if (!term) return true;
+      const name = (role.nombre ?? '').toLowerCase();
+      const description = (role.descripcion ?? '').toLowerCase();
+      return name.includes(term) || description.includes(term);
+    })
+    .sort((a, b) => (a.nombre ?? '').localeCompare(b.nombre ?? ''));
+};
+
+export async function getRoles(params: GetRolesParams = {}): Promise<PaginatedResult<Role>> {
+  const { page = 1, limit = 10, search = '', showInactive = false, ...rest } = params;
+  const query: Record<string, unknown> = { ...rest };
+  if (params.page != null) query.page = page;
+  if (params.limit != null) query.limit = limit;
+  if (search.trim() !== '') query.search = search.trim();
+
+  const { data } = await api.get('/roles', { params: query });
+  const pag = unwrapPaginated<Role>(data);
+  if (hasPaginationMeta(pag.meta)) {
+    const meta = normalizePaginationMeta(pag.meta, { page, limit });
+    const items = (pag.items.length ? pag.items : normalizeList<Role>(data)) as Role[];
+    return { items, meta };
+  }
+
+  const list = normalizeList<Role>(data);
+  const filtered = filterRoles(list, search, showInactive);
+  return paginateArray(filtered, { page, limit });
 }
 
 export async function createRole(body: any) {


### PR DESCRIPTION
## Summary
- allow the shared pagination hook to accept normalized `PaginationMeta` objects and legacy meta shapes without type errors
- normalise role management flows by treating IDs as strings in the UI, coercing them to numbers for service calls, and tightening the modal form typing
- extend document and user helpers to expose the fields expected by the supervision and general listings so the new pagination plumbing works with legacy payloads

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cc7c5ccc548332b17d5c8d94632766