### PR TITLE
Format displayed dates with Guatemala locale

### DIFF
--- a/src/app/admin/documentos/page.tsx
+++ b/src/app/admin/documentos/page.tsx
@@ -17,7 +17,6 @@ import { useServerPagination } from "@/hooks/useServerPagination";
 
 function toUiDocument(d: DocumentoRow): Document {
   const add = d.add_date ?? "";
-  const onlyDate = add ? String(add).split("T")[0] : "";
   const assignedUsers = (d.firmantesResumen && d.firmantesResumen.length
     ? d.firmantesResumen
     : Array.from({ length: 3 }).map((_, i) => ({
@@ -39,7 +38,7 @@ function toUiDocument(d: DocumentoRow): Document {
     code: "",
     name: d.titulo ?? "",
     description: d.descripcion ?? "",
-    sendDate: onlyDate,
+    sendDate: add,
     status: (d.estado?.nombre ?? "") as Document["status"],
     businessDays: d.diasTranscurridos ?? 0,
     assignedUsers,

--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -18,7 +18,6 @@ import { useServerPagination } from "@/hooks/useServerPagination";
 function toUiDocument(a: AsignacionDTO): Document {
   const cf = a.cuadro_firma;
   const add = cf.add_date ?? "";
-  const onlyDate = add ? String(add).split("T")[0] : "";
   const srcFirmantes =
     Array.isArray((cf as any).firmantesResumen) && (cf as any).firmantesResumen.length
       ? (cf as any).firmantesResumen
@@ -58,7 +57,7 @@ function toUiDocument(a: AsignacionDTO): Document {
     code: cf.codigo ?? "",
     name: cf.titulo ?? "",
     description: cf.descripcion ?? "",
-    sendDate: onlyDate,
+    sendDate: add,
     status: (cf.estado_firma?.nombre ?? "") as Document["status"],
     businessDays: cf.diasTranscurridos ?? 0,
     assignedUsers,

--- a/src/app/general/page.tsx
+++ b/src/app/general/page.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { DocumentsTable } from "@/components/documents-table";
 import { Document } from "@/lib/data";
+import { getTime } from "@/lib/date";
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getDocumentsByUser, type AsignacionDTO } from "@/services/documentsService";
@@ -61,8 +62,8 @@ export default function GeneralPage() {
                 return matchesSearch && matchesStatus;
             })
             .sort((a, b) => {
-                const aDate = a.sendDate ? Date.parse(a.sendDate) : 0;
-                const bDate = b.sendDate ? Date.parse(b.sendDate) : 0;
+                const aDate = getTime(a.sendDate);
+                const bDate = getTime(b.sendDate);
                 return sortOrder === 'asc' ? aDate - bDate : bDate - aDate;
             });
     }, [documents, searchTerm, statusFilter, sortOrder]);

--- a/src/components/DateCell.tsx
+++ b/src/components/DateCell.tsx
@@ -1,0 +1,9 @@
+'use client';
+import React from 'react';
+import { formatGT, formatGTDateTime } from '@/lib/date';
+
+export function DateCell({ value, withTime = false }: { value?: string | Date | null; withTime?: boolean }) {
+  const shown = withTime ? formatGTDateTime(value) : formatGT(value);
+  const title = formatGTDateTime(value) || '';
+  return <span title={title}>{shown || '—'}</span>;
+}

--- a/src/components/documents-table.tsx
+++ b/src/components/documents-table.tsx
@@ -26,6 +26,7 @@ import { Button } from "./ui/button";
 import { useRouter } from "next/navigation";
 import { initialsFromUser } from "@/lib/avatar";
 import { PaginationBar } from "./pagination/PaginationBar";
+import { DateCell } from "@/components/DateCell";
 
 interface DocumentsTableProps {
   documents: Document[];
@@ -221,7 +222,7 @@ export function DocumentsTable({
                     {doc.description}
                   </TableCell>
                   <TableCell className="hidden sm:table-cell">
-                    {doc.sendDate}
+                    <DateCell value={doc.sendDate} withTime />
                   </TableCell>
                   <TableCell>
                     <Badge className={cn("border", getStatusClass(doc.status))}>

--- a/src/components/pages-table.tsx
+++ b/src/components/pages-table.tsx
@@ -11,8 +11,8 @@ import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
 import { PageFormModal, PageForm } from './page-form-modal';
 import type { Page } from '@/services/pageService';
-import { format } from 'date-fns';
 import { PaginationBar } from './pagination/PaginationBar';
+import { DateCell } from '@/components/DateCell';
 
 interface PagesTableProps {
   pages: Page[];
@@ -117,7 +117,7 @@ export function PagesTable({
                     </Badge>
                   </TableCell>
                   <TableCell className="hidden md:table-cell">
-                    {page.createdAt ? format(new Date(page.createdAt), 'dd/MM/yyyy') : ''}
+                    <DateCell value={page.createdAt} />
                   </TableCell>
                   <TableCell>
                     <DropdownMenu>

--- a/src/components/roles-table.tsx
+++ b/src/components/roles-table.tsx
@@ -11,8 +11,8 @@ import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
 import { RoleFormModal, RoleForm } from './role-form-modal';
 import type { Role } from '@/services/roleService';
-import { format } from 'date-fns';
 import { PaginationBar } from './pagination/PaginationBar';
+import { DateCell } from '@/components/DateCell';
 
 interface RolesTableProps {
   roles: Role[];
@@ -115,7 +115,7 @@ export function RolesTable({
                     </Badge>
                   </TableCell>
                   <TableCell className="hidden md:table-cell">
-                    {role.createdAt ? format(new Date(role.createdAt), 'dd/MM/yyyy') : ''}
+                    <DateCell value={role.createdAt} />
                   </TableCell>
                   <TableCell>
                     <DropdownMenu>

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,36 @@
+const GT_TZ = 'America/Guatemala';
+
+function toDate(input?: string | Date | null) {
+  if (!input) return null;
+  return typeof input === 'string' ? new Date(input) : input;
+}
+
+export function formatGT(input?: string | Date | null) {
+  const d = toDate(input);
+  if (!d) return '';
+  return new Intl.DateTimeFormat('es-GT', {
+    timeZone: GT_TZ,
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(d);
+}
+
+export function formatGTDateTime(input?: string | Date | null) {
+  const d = toDate(input);
+  if (!d) return '';
+  return new Intl.DateTimeFormat('es-GT', {
+    timeZone: GT_TZ,
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(d);
+}
+
+export function getTime(input?: string | Date | null) {
+  const d = toDate(input);
+  return d ? d.getTime() : 0;
+}

--- a/src/services/documentsService.ts
+++ b/src/services/documentsService.ts
@@ -2,6 +2,7 @@ import { api } from '@/lib/api';
 import { unwrapArray, unwrapPaginated, unwrapOne } from '@/lib/apiEnvelope';
 import { hasPaginationMeta, normalizePaginationMeta, paginateArray, type PaginatedResult } from '@/lib/pagination';
 import { initials, fullName, initialsFromFullName } from '@/lib/avatar';
+import { getTime } from '@/lib/date';
 
 export type DocEstado = 'Pendiente' | 'En Progreso' | 'Rechazado' | 'Completado';
 export type SupervisionDoc = {
@@ -210,11 +211,7 @@ const toSupervisionDoc = (d: any): SupervisionDoc => {
   };
 };
 
-const parseDateValue = (value?: string | null) => {
-  if (!value) return 0;
-  const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? timestamp : 0;
-};
+const parseDateValue = (value?: string | null) => getTime(value);
 
 export async function createCuadroFirma(body: FormData) {
   const { data } = await api.post('/documents/cuadro-firmas', body, { timeout: 60000 });


### PR DESCRIPTION
## Summary
- add reusable Guatemala timezone date formatter utilities and DateCell component
- display document, role, and page dates via the new component while keeping ISO data for sorting
- align document data mapping and services sorting with the shared getTime helper

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc88953c648332a6761e19474694e5