### PR TITLE
Align pagination and search handling across admin tables

### DIFF
--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useMemo } from "react";
+import React, { useState, useEffect, useMemo, useRef } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { DocumentsTable } from "@/components/documents-table";
 import type { Document } from "@/lib/data";
@@ -76,25 +76,40 @@ const defaultCounts: Record<Document["status"] | "Todos", number> = {
 };
 
 export default function MisDocumentosPage() {
-  const [searchInput, setSearchInput] = useState("");
-  const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState<Document["status"] | "Todos">("Todos");
   const [firmantes, setFirmantes] = useState<any[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const { toast } = useToast();
-  const { page, limit, sort, setPage, setLimit, toggleSort } = usePaginationState({
+  const { page, limit, sort, search, setPage, setLimit, setSearch, toggleSort } = usePaginationState({
     defaultLimit: 10,
     defaultSort: "desc",
   });
   const sortOrder: "asc" | "desc" = sort;
+  const [searchInput, setSearchInput] = useState(() => search);
+  const initialSearchRef = useRef(search);
+  const isFirstSearchEffect = useRef(true);
 
   useEffect(() => {
-    const handler = setTimeout(() => {
+    initialSearchRef.current = search;
+    setSearchInput((current) => (current === search ? current : search));
+    isFirstSearchEffect.current = true;
+  }, [search]);
+
+  useEffect(() => {
+    const handler = window.setTimeout(() => {
+      if (isFirstSearchEffect.current) {
+        isFirstSearchEffect.current = false;
+        if (searchInput === initialSearchRef.current) {
+          return;
+        }
+      }
       setSearch(searchInput);
       setPage(1);
     }, 300);
-    return () => clearTimeout(handler);
+    return () => {
+      window.clearTimeout(handler);
+    };
   }, [searchInput, setPage, setSearch]);
 
   const meQuery = useQuery({
@@ -138,8 +153,8 @@ export default function MisDocumentosPage() {
         page,
         limit,
         sort: sortOrder,
+        search,
       };
-      if (search) params.search = search;
       if (statusFilter !== "Todos") params.estado = statusFilter;
       const response = await getDocumentsByUser(userId, params);
       return {
@@ -216,18 +231,11 @@ export default function MisDocumentosPage() {
   }
 
   const payload = documentsQuery.data;
-  const documents = payload?.items ?? [];
-  const total = payload?.total ?? 0;
-  const totalPages = payload?.pages ?? 1;
-  const currentPage = payload?.page ?? page;
-  const hasPrev = payload?.hasPrev ?? currentPage > 1;
-  const hasNext = payload?.hasNext ?? currentPage < totalPages;
-  const currentLimit = payload?.limit ?? limit;
 
   return (
     <div className="h-full">
       <DocumentsTable
-        items={documents}
+        data={payload}
         title="Mis Documentos"
         description="Documentos asignados a usted para revisar y firmar."
         searchTerm={searchInput}
@@ -240,21 +248,11 @@ export default function MisDocumentosPage() {
         sortOrder={sortOrder}
         onSortToggle={() => {
           toggleSort();
-          setPage(1);
         }}
         onAsignadosClick={handleAsignadosClick}
         statusCounts={counts}
-        total={total}
-        pages={totalPages}
-        hasPrev={hasPrev}
-        hasNext={hasNext}
-        page={currentPage}
-        limit={currentLimit}
         onPageChange={setPage}
-        onLimitChange={(value) => {
-          setLimit(value);
-          setPage(1);
-        }}
+        onLimitChange={setLimit}
         loading={documentsQuery.isFetching}
       />
       <SignersModal

--- a/src/app/admin/page/page.tsx
+++ b/src/app/admin/page/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { PagesTable } from '@/components/pages-table';
 import {
@@ -18,16 +18,29 @@ import { usePaginationState } from '@/hooks/usePaginationState';
 
 export default function PageAdminPage() {
   const [showInactive, setShowInactive] = useState(false);
-  const [searchInput, setSearchInput] = useState('');
-  const [search, setSearch] = useState('');
   const { toast } = useToast();
-  const { page, limit, sort, setPage, setLimit } = usePaginationState({
+  const { page, limit, sort, search, setPage, setLimit, setSearch } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
+  const [searchInput, setSearchInput] = useState(() => search);
+  const initialSearchRef = useRef(search);
+  const isFirstSearchEffect = useRef(true);
 
   useEffect(() => {
-    const handler = setTimeout(() => {
+    initialSearchRef.current = search;
+    setSearchInput((current) => (current === search ? current : search));
+    isFirstSearchEffect.current = true;
+  }, [search]);
+
+  useEffect(() => {
+    const handler = window.setTimeout(() => {
+      if (isFirstSearchEffect.current) {
+        isFirstSearchEffect.current = false;
+        if (searchInput === initialSearchRef.current) {
+          return;
+        }
+      }
       setSearch(searchInput);
       setPage(1);
     }, 300);
@@ -124,29 +137,13 @@ export default function PageAdminPage() {
   }
 
   const payload = pagesQuery.data;
-  const items = payload?.items ?? [];
-  const total = payload?.total ?? 0;
-  const totalPages = payload?.pages ?? 1;
-  const currentPage = payload?.page ?? page;
-  const currentLimit = payload?.limit ?? limit;
-  const hasPrev = payload?.hasPrev ?? currentPage > 1;
-  const hasNext = payload?.hasNext ?? currentPage < totalPages;
 
   return (
     <div className="h-full">
       <PagesTable
-        items={items}
-        total={total}
-        pages={totalPages}
-        hasPrev={hasPrev}
-        hasNext={hasNext}
-        page={currentPage}
-        limit={currentLimit}
+        data={payload}
         onPageChange={setPage}
-        onLimitChange={(value) => {
-          setLimit(value);
-          setPage(1);
-        }}
+        onLimitChange={setLimit}
         searchTerm={searchInput}
         onSearchChange={setSearchInput}
         showInactive={showInactive}

--- a/src/components/documents-table.tsx
+++ b/src/components/documents-table.tsx
@@ -27,9 +27,10 @@ import { useRouter } from "next/navigation";
 import { initialsFromUser } from "@/lib/avatar";
 import { PaginationBar } from "./pagination/PaginationBar";
 import { DateCell } from "@/components/DateCell";
+import type { PageEnvelope } from "@/lib/pagination";
 
 interface DocumentsTableProps {
-  items: Document[];
+  data?: PageEnvelope<Document>;
   title: string;
   description: string;
   searchTerm: string;
@@ -40,12 +41,6 @@ interface DocumentsTableProps {
   onSortToggle: () => void;
   onAsignadosClick?: (doc: Document) => void;
   statusCounts?: Record<Document["status"] | "Todos", number>;
-  total: number;
-  pages: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  page: number;
-  limit: number;
   onPageChange: (page: number) => void;
   onLimitChange: (limit: number) => void;
   loading?: boolean;
@@ -113,7 +108,7 @@ const AvatarGroup: React.FC<{ users?: DocumentUser[] }> = ({ users = [] }) => (
 );
 
 export function DocumentsTable({
-  items,
+  data,
   title,
   description,
   searchTerm,
@@ -124,12 +119,6 @@ export function DocumentsTable({
   onSortToggle,
   onAsignadosClick,
   statusCounts,
-  total,
-  pages,
-  hasPrev,
-  hasNext,
-  page,
-  limit,
   onPageChange,
   onLimitChange,
   loading = false,
@@ -148,7 +137,13 @@ export function DocumentsTable({
     router.push(`/documento/${docId}`);
   };
 
-  const documents = Array.isArray(items) ? items : [];
+  const documents = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.pages ?? 1;
+  const currentPage = data?.page ?? 1;
+  const hasPrev = Boolean(data?.hasPrev);
+  const hasNext = Boolean(data?.hasNext);
+  const currentLimit = data?.limit ?? 10;
 
   return (
     <Card className="w-full h-full flex flex-col glassmorphism">
@@ -263,9 +258,9 @@ export function DocumentsTable({
       </CardContent>
       <PaginationBar
         total={total}
-        page={page}
-        pages={pages}
-        limit={limit}
+        page={currentPage}
+        pages={totalPages}
+        limit={currentLimit}
         hasPrev={hasPrev}
         hasNext={hasNext}
         onPageChange={onPageChange}

--- a/src/components/pages-table.tsx
+++ b/src/components/pages-table.tsx
@@ -13,15 +13,10 @@ import { PageFormModal, PageForm } from './page-form-modal';
 import type { Page } from '@/services/pageService';
 import { PaginationBar } from './pagination/PaginationBar';
 import { DateCell } from '@/components/DateCell';
+import type { PageEnvelope } from '@/lib/pagination';
 
 interface PagesTableProps {
-  items: Page[];
-  total: number;
-  pages: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  page: number;
-  limit: number;
+  data?: PageEnvelope<Page>;
   onPageChange: (page: number) => void;
   onLimitChange: (limit: number) => void;
   searchTerm: string;
@@ -35,13 +30,7 @@ interface PagesTableProps {
 }
 
 export function PagesTable({
-  items,
-  total,
-  pages,
-  hasPrev,
-  hasNext,
-  page,
-  limit,
+  data,
   onPageChange,
   onLimitChange,
   searchTerm,
@@ -56,7 +45,13 @@ export function PagesTable({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPage, setSelectedPage] = useState<Page | undefined>(undefined);
 
-  const rows = Array.isArray(items) ? items : [];
+  const rows = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.pages ?? 1;
+  const currentPage = data?.page ?? 1;
+  const hasPrev = Boolean(data?.hasPrev);
+  const hasNext = Boolean(data?.hasNext);
+  const currentLimit = data?.limit ?? 10;
 
   const openModal = (page?: Page) => {
     setSelectedPage(page);
@@ -170,9 +165,9 @@ export function PagesTable({
       </CardContent>
       <PaginationBar
         total={total}
-        page={page}
-        pages={pages}
-        limit={limit}
+        page={currentPage}
+        pages={totalPages}
+        limit={currentLimit}
         hasPrev={hasPrev}
         hasNext={hasNext}
         onPageChange={onPageChange}

--- a/src/components/pagination/PaginationBar.tsx
+++ b/src/components/pagination/PaginationBar.tsx
@@ -39,11 +39,8 @@ export function PaginationBar({
   className,
 }: PaginationBarProps) {
   const size = Number.isFinite(limit) && limit > 0 ? Math.floor(limit) : DEFAULT_OPTIONS[0];
-  const totalPages =
-    Number.isFinite(pages) && pages > 0
-      ? Math.floor(pages)
-      : Math.max(1, Math.ceil(((Number.isFinite(total) ? Math.max(0, total) : 0) / size) || 0) || 1);
-  const currentPage = Math.min(Math.max(1, Math.floor(page || 1)), totalPages);
+  const totalPages = Number.isFinite(pages) && pages > 0 ? Math.floor(pages) : 1;
+  const currentPage = Number.isFinite(page) && page > 0 ? Math.floor(page) : 1;
 
   const options = useMemo(() => {
     const set = new Set<number>();
@@ -59,7 +56,7 @@ export function PaginationBar({
   };
 
   const handleNext = () => {
-    if (!hasNext || currentPage >= totalPages) return;
+    if (!hasNext) return;
     onPageChange(currentPage + 1);
   };
 
@@ -111,7 +108,7 @@ export function PaginationBar({
             variant="outline"
             size="sm"
             onClick={handleNext}
-            disabled={!hasNext || currentPage >= totalPages}
+            disabled={!hasNext}
             aria-label="Página siguiente"
           >
             Siguiente ⟩

--- a/src/components/roles-table.tsx
+++ b/src/components/roles-table.tsx
@@ -13,15 +13,10 @@ import { RoleFormModal, RoleForm } from './role-form-modal';
 import type { Role } from '@/services/roleService';
 import { PaginationBar } from './pagination/PaginationBar';
 import { DateCell } from '@/components/DateCell';
+import type { PageEnvelope } from '@/lib/pagination';
 
 interface RolesTableProps {
-  items: Role[];
-  total: number;
-  pages: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  page: number;
-  limit: number;
+  data?: PageEnvelope<Role>;
   onPageChange: (page: number) => void;
   onLimitChange: (limit: number) => void;
   searchTerm: string;
@@ -35,13 +30,7 @@ interface RolesTableProps {
 }
 
 export function RolesTable({
-  items,
-  total,
-  pages,
-  hasPrev,
-  hasNext,
-  page,
-  limit,
+  data,
   onPageChange,
   onLimitChange,
   searchTerm,
@@ -56,7 +45,13 @@ export function RolesTable({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
 
-  const roles = Array.isArray(items) ? items : [];
+  const roles = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.pages ?? 1;
+  const currentPage = data?.page ?? 1;
+  const hasPrev = Boolean(data?.hasPrev);
+  const hasNext = Boolean(data?.hasNext);
+  const currentLimit = data?.limit ?? 10;
 
   const openModal = (role?: Role) => {
     setSelectedRole(role ?? null);
@@ -171,9 +166,9 @@ export function RolesTable({
       </CardContent>
       <PaginationBar
         total={total}
-        page={page}
-        pages={pages}
-        limit={limit}
+        page={currentPage}
+        pages={totalPages}
+        limit={currentLimit}
         hasPrev={hasPrev}
         hasNext={hasNext}
         onPageChange={onPageChange}

--- a/src/components/supervision-table.tsx
+++ b/src/components/supervision-table.tsx
@@ -10,9 +10,10 @@ import { cn } from '@/lib/utils';
 import { Button } from './ui/button';
 import type { SupervisionDoc, DocEstado } from '@/services/documentsService';
 import { PaginationBar } from './pagination/PaginationBar';
+import type { PageEnvelope } from '@/lib/pagination';
 
 interface SupervisionTableProps {
-  items: SupervisionDoc[];
+  data?: PageEnvelope<SupervisionDoc>;
   title: string;
   description: string;
   searchTerm: string;
@@ -22,12 +23,6 @@ interface SupervisionTableProps {
   sortOrder: 'asc' | 'desc';
   onSortToggle: () => void;
   statusCounts?: Record<DocEstado | 'Todos', number>;
-  total: number;
-  pages: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  page: number;
-  limit: number;
   onPageChange: (page: number) => void;
   onLimitChange: (limit: number) => void;
   loading?: boolean;
@@ -66,7 +61,7 @@ const getButtonStatusClass = (status: DocEstado | 'Todos', current: DocEstado | 
 };
 
 export function SupervisionTable({
-  items,
+  data,
   title,
   description,
   searchTerm,
@@ -76,17 +71,17 @@ export function SupervisionTable({
   sortOrder,
   onSortToggle,
   statusCounts,
-  total,
-  pages,
-  hasPrev,
-  hasNext,
-  page,
-  limit,
   onPageChange,
   onLimitChange,
   loading = false,
 }: SupervisionTableProps) {
-  const documents = Array.isArray(items) ? items : [];
+  const documents = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.pages ?? 1;
+  const currentPage = data?.page ?? 1;
+  const hasPrev = Boolean(data?.hasPrev);
+  const hasNext = Boolean(data?.hasNext);
+  const currentLimit = data?.limit ?? 10;
   const fallbackCounts = useMemo(
     () =>
       documents.reduce(
@@ -178,9 +173,9 @@ export function SupervisionTable({
       </CardContent>
       <PaginationBar
         total={total}
-        page={page}
-        pages={pages}
-        limit={limit}
+        page={currentPage}
+        pages={totalPages}
+        limit={currentLimit}
         hasPrev={hasPrev}
         hasNext={hasNext}
         onPageChange={onPageChange}

--- a/src/components/users-table.tsx
+++ b/src/components/users-table.tsx
@@ -15,15 +15,10 @@ import { Badge } from './ui/badge';
 import { UserPasswordDialog } from './user-password-dialog';
 import { useSession } from '@/lib/session';
 import { PaginationBar } from './pagination/PaginationBar';
+import type { PageEnvelope } from '@/lib/pagination';
 
 interface UsersTableProps {
-  items: User[];
-  total: number;
-  pages: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  page: number;
-  limit: number;
+  data?: PageEnvelope<User>;
   onPageChange: (page: number) => void;
   onLimitChange: (limit: number) => void;
   searchTerm: string;
@@ -43,13 +38,7 @@ const getInitials = (u: User) => {
 };
 
 export function UsersTable({
-  items,
-  total,
-  pages,
-  hasPrev,
-  hasNext,
-  page,
-  limit,
+  data,
   onPageChange,
   onLimitChange,
   searchTerm,
@@ -65,7 +54,13 @@ export function UsersTable({
   const { me } = useSession();
   const [passwordDialogUser, setPasswordDialogUser] = useState<{ user: User; requireCurrent: boolean } | null>(null);
 
-  const users = Array.isArray(items) ? items : [];
+  const users = data?.items ?? [];
+  const total = data?.total ?? 0;
+  const totalPages = data?.pages ?? 1;
+  const currentPage = data?.page ?? 1;
+  const hasPrev = Boolean(data?.hasPrev);
+  const hasNext = Boolean(data?.hasNext);
+  const currentLimit = data?.limit ?? 10;
 
   const handleOpenModal = (user?: User) => {
     setSelectedUser(user);
@@ -230,9 +225,9 @@ export function UsersTable({
       </CardContent>
       <PaginationBar
         total={total}
-        page={page}
-        pages={pages}
-        limit={limit}
+        page={currentPage}
+        pages={totalPages}
+        limit={currentLimit}
         hasPrev={hasPrev}
         hasNext={hasNext}
         onPageChange={onPageChange}


### PR DESCRIPTION
## Summary
- extend `usePaginationState` to include search synchronization with URL params and guard router updates against redundant replacements.
- ensure `PaginationBar` and all table components consume server-provided pagination payloads instead of deriving client values.
- normalize admin list pages to debounce search input, reset pagination consistently, and pass the paginated payloads directly into their tables.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc7696b088332a195945626a6f386