### PR TITLE
Instrument pagination state to prevent page reset flapping

### DIFF
--- a/src/app/admin/mis-documentos/page.tsx
+++ b/src/app/admin/mis-documentos/page.tsx
@@ -16,6 +16,7 @@ import {
 import { getMe } from "@/services/usersService";
 import { SignersModal } from "@/components/signers-modal";
 import { usePaginationState } from "@/hooks/usePaginationState";
+import { pageDebug } from "@/lib/page-debug";
 
 function toUiDocument(a: AsignacionDTO): Document {
   const cf = a.cuadro_firma;
@@ -81,7 +82,17 @@ export default function MisDocumentosPage() {
   const [modalOpen, setModalOpen] = useState(false);
   const [modalLoading, setModalLoading] = useState(false);
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch, toggleSort } = usePaginationState({
+  const {
+    page,
+    limit,
+    sort,
+    search,
+    setPage,
+    setLimit,
+    setSearch,
+    toggleSort,
+    isUserPagingRef,
+  } = usePaginationState({
     defaultLimit: 10,
     defaultSort: "desc",
   });
@@ -105,6 +116,20 @@ export default function MisDocumentosPage() {
         }
       }
       setSearch(searchInput);
+      if (isUserPagingRef.current) {
+        pageDebug("src/app/admin/mis-documentos/page.tsx:120:setPage(skip)", {
+          reason: "userPaging",
+          from: page,
+          to: 1,
+          searchInput,
+        });
+        return;
+      }
+      pageDebug("src/app/admin/mis-documentos/page.tsx:128:setPage", {
+        from: page,
+        to: 1,
+        searchInput,
+      });
       setPage(1);
     }, 300);
     return () => {
@@ -183,6 +208,7 @@ export default function MisDocumentosPage() {
       const resumen = await getByUserStats(userId, { search });
       return resumen;
     },
+    keepPreviousData: true,
     retry: false,
   });
 
@@ -243,7 +269,23 @@ export default function MisDocumentosPage() {
         statusFilter={statusFilter}
         onStatusFilterChange={(s) => {
           setStatusFilter(s);
-          if (page !== 1) setPage(1);
+          if (page !== 1) {
+            if (isUserPagingRef.current) {
+              pageDebug("src/app/admin/mis-documentos/page.tsx:273:setPage(skip)", {
+                reason: "userPaging",
+                from: page,
+                to: 1,
+                status: s,
+              });
+              return;
+            }
+            pageDebug("src/app/admin/mis-documentos/page.tsx:281:setPage", {
+              from: page,
+              to: 1,
+              status: s,
+            });
+            setPage(1);
+          }
         }}
         sortOrder={sortOrder}
         onSortToggle={() => {

--- a/src/app/admin/page/page.tsx
+++ b/src/app/admin/page/page.tsx
@@ -15,11 +15,12 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { pageDebug } from '@/lib/page-debug';
 
 export default function PageAdminPage() {
   const [showInactive, setShowInactive] = useState(false);
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch } = usePaginationState({
+  const { page, limit, sort, search, setPage, setLimit, setSearch, isUserPagingRef } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
@@ -42,6 +43,20 @@ export default function PageAdminPage() {
         }
       }
       setSearch(searchInput);
+      if (isUserPagingRef.current) {
+        pageDebug('src/app/admin/page/page.tsx:47:setPage(skip)', {
+          reason: 'userPaging',
+          from: page,
+          to: 1,
+          searchInput,
+        });
+        return;
+      }
+      pageDebug('src/app/admin/page/page.tsx:55:setPage', {
+        from: page,
+        to: 1,
+        searchInput,
+      });
       setPage(1);
     }, 300);
     return () => clearTimeout(handler);
@@ -78,6 +93,18 @@ export default function PageAdminPage() {
         await createPage(pageData as any);
         toast({ title: 'Página creada', description: 'La nueva página ha sido agregada.' });
         if (page !== 1) {
+          if (isUserPagingRef.current) {
+            pageDebug('src/app/admin/page/page.tsx:97:setPage(skip)', {
+              reason: 'userPaging',
+              from: page,
+              to: 1,
+            });
+            return;
+          }
+          pageDebug('src/app/admin/page/page.tsx:104:setPage', {
+            from: page,
+            to: 1,
+          });
           setPage(1);
           return;
         }
@@ -149,7 +176,23 @@ export default function PageAdminPage() {
         showInactive={showInactive}
         onToggleInactive={(checked) => {
           setShowInactive(checked);
-          if (page !== 1) setPage(1);
+          if (page !== 1) {
+            if (isUserPagingRef.current) {
+              pageDebug('src/app/admin/page/page.tsx:181:setPage(skip)', {
+                reason: 'userPaging',
+                from: page,
+                to: 1,
+                showInactive: checked,
+              });
+              return;
+            }
+            pageDebug('src/app/admin/page/page.tsx:189:setPage', {
+              from: page,
+              to: 1,
+              showInactive: checked,
+            });
+            setPage(1);
+          }
         }}
         onSavePage={handleSavePage}
         onDeletePage={handleDeletePage}

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -15,12 +15,13 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { pageDebug } from '@/lib/page-debug';
 import type { RoleForm } from '@/components/role-form-modal';
 
 export default function RolesPage() {
   const [showInactive, setShowInactive] = useState(false);
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch } = usePaginationState({
+  const { page, limit, sort, search, setPage, setLimit, setSearch, isUserPagingRef } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
@@ -43,6 +44,20 @@ export default function RolesPage() {
         }
       }
       setSearch(searchInput);
+      if (isUserPagingRef.current) {
+        pageDebug('src/app/admin/roles/page.tsx:48:setPage(skip)', {
+          reason: 'userPaging',
+          from: page,
+          to: 1,
+          searchInput,
+        });
+        return;
+      }
+      pageDebug('src/app/admin/roles/page.tsx:56:setPage', {
+        from: page,
+        to: 1,
+        searchInput,
+      });
       setPage(1);
     }, 300);
     return () => clearTimeout(handler);
@@ -88,6 +103,18 @@ export default function RolesPage() {
         await createRole({ nombre: role.nombre, descripcion: role.descripcion });
         toast({ title: 'Rol creado', description: 'El nuevo rol ha sido agregado.' });
         if (page !== 1) {
+          if (isUserPagingRef.current) {
+            pageDebug('src/app/admin/roles/page.tsx:107:setPage(skip)', {
+              reason: 'userPaging',
+              from: page,
+              to: 1,
+            });
+            return;
+          }
+          pageDebug('src/app/admin/roles/page.tsx:114:setPage', {
+            from: page,
+            to: 1,
+          });
           setPage(1);
           return;
         }
@@ -177,7 +204,23 @@ export default function RolesPage() {
         showInactive={showInactive}
         onToggleInactive={(checked) => {
           setShowInactive(checked);
-          if (page !== 1) setPage(1);
+          if (page !== 1) {
+            if (isUserPagingRef.current) {
+              pageDebug('src/app/admin/roles/page.tsx:209:setPage(skip)', {
+                reason: 'userPaging',
+                from: page,
+                to: 1,
+                showInactive: checked,
+              });
+              return;
+            }
+            pageDebug('src/app/admin/roles/page.tsx:217:setPage', {
+              from: page,
+              to: 1,
+              showInactive: checked,
+            });
+            setPage(1);
+          }
         }}
         onSaveRole={handleSaveRole}
         onDeleteRole={handleDeleteRole}

--- a/src/app/admin/usuarios/page.tsx
+++ b/src/app/admin/usuarios/page.tsx
@@ -15,10 +15,11 @@ import {
 } from '@/services/usersService';
 import type { User } from '@/lib/data';
 import { usePaginationState } from '@/hooks/usePaginationState';
+import { pageDebug } from '@/lib/page-debug';
 
 export default function UsuariosPage() {
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch } = usePaginationState({
+  const { page, limit, sort, search, setPage, setLimit, setSearch, isUserPagingRef } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
@@ -41,6 +42,20 @@ export default function UsuariosPage() {
         }
       }
       setSearch(searchInput);
+      if (isUserPagingRef.current) {
+        pageDebug('src/app/admin/usuarios/page.tsx:46:setPage(skip)', {
+          reason: 'userPaging',
+          from: page,
+          to: 1,
+          searchInput,
+        });
+        return;
+      }
+      pageDebug('src/app/admin/usuarios/page.tsx:54:setPage', {
+        from: page,
+        to: 1,
+        searchInput,
+      });
       setPage(1);
     }, 300);
     return () => window.clearTimeout(handler);
@@ -75,6 +90,18 @@ export default function UsuariosPage() {
         await createUser(formData);
         toast({ title: 'Usuario Creado', description: 'El nuevo usuario ha sido agregado exitosamente.' });
         if (page !== 1) {
+          if (isUserPagingRef.current) {
+            pageDebug('src/app/admin/usuarios/page.tsx:94:setPage(skip)', {
+              reason: 'userPaging',
+              from: page,
+              to: 1,
+            });
+            return;
+          }
+          pageDebug('src/app/admin/usuarios/page.tsx:101:setPage', {
+            from: page,
+            to: 1,
+          });
           setPage(1);
         } else {
           await usersQuery.refetch();

--- a/src/components/pagination/PaginationBar.tsx
+++ b/src/components/pagination/PaginationBar.tsx
@@ -10,6 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
+import { pageDebug } from "@/lib/page-debug";
 
 const DEFAULT_OPTIONS = [10, 20, 50, 100] as const;
 
@@ -52,11 +53,19 @@ export function PaginationBar({
 
   const handlePrev = () => {
     if (!hasPrev || currentPage <= 1) return;
+    pageDebug("src/components/pagination/PaginationBar.tsx:56:onPageChange", {
+      from: currentPage,
+      to: currentPage - 1,
+    });
     onPageChange(currentPage - 1);
   };
 
   const handleNext = () => {
     if (!hasNext) return;
+    pageDebug("src/components/pagination/PaginationBar.tsx:65:onPageChange", {
+      from: currentPage,
+      to: currentPage + 1,
+    });
     onPageChange(currentPage + 1);
   };
 

--- a/src/lib/page-debug.ts
+++ b/src/lib/page-debug.ts
@@ -1,0 +1,36 @@
+"use client";
+
+export interface PageDebugPayload {
+  from?: unknown;
+  to?: unknown;
+  locationSearch?: string;
+  [key: string]: unknown;
+}
+
+export const pageDebug = (label: string, payload: PageDebugPayload = {}) => {
+  if (process.env.NEXT_PUBLIC_PAGE_DEBUG !== "1") return;
+
+  const locationSearch =
+    typeof window !== "undefined" ? window.location.search : payload.locationSearch;
+
+  const entry = {
+    label,
+    data: {
+      ...payload,
+      from: payload.from,
+      to: payload.to,
+      locationSearch,
+    },
+    timestamp: Date.now(),
+  };
+
+  if (typeof window !== "undefined") {
+    const storeKey = "__PAGE_DEBUG_LOGS__";
+    const globalAny = window as unknown as Record<string, unknown>;
+    const store = (globalAny[storeKey] as unknown[]) ?? [];
+    store.push(entry);
+    globalAny[storeKey] = store;
+  }
+
+  console.debug("[PAGE_DEBUG]", entry.label, entry.data);
+};


### PR DESCRIPTION
## Summary
- add a reusable `pageDebug` helper that records pagination diagnostics when `NEXT_PUBLIC_PAGE_DEBUG=1`
- instrument `usePaginationState` and every admin listing to log callers, guard filter effects with `isUserPagingRef`, and keep query state stable
- emit debug output from `PaginationBar` while preserving query params and avoiding unintended `setPage(1)` resets

## Testing
- npm run lint

## Debug evidence
![PAGE_DEBUG capture](browser:/invocations/ftlafsrb/artifacts/artifacts/page-debug.png)


------
https://chatgpt.com/codex/tasks/task_e_68ccd1dca0208332a757bbd29d7fa5da