### PR TITLE
Add elapsed days tooltip cells

### DIFF
--- a/src/components/ElapsedDaysCell.tsx
+++ b/src/components/ElapsedDaysCell.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { elapsedDaysGT, formatElapsedDaysLabel, formatGTDateTime } from '@/lib/date';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+type Props = {
+  fromISO?: string | null;
+  title?: string;
+};
+
+export function ElapsedDaysCell({ fromISO, title }: Props) {
+  if (!fromISO) {
+    return <span className="text-muted-foreground">—</span>;
+  }
+
+  const days = elapsedDaysGT(fromISO);
+  const label = formatElapsedDaysLabel(days);
+  const formatted = formatGTDateTime(fromISO, { ampm: 'upper' });
+  const tooltip = title ?? (formatted ? `${formatted} GT` : label);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="text-muted-foreground" aria-label={label}>
+          {label}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/documents-table.tsx
+++ b/src/components/documents-table.tsx
@@ -27,6 +27,8 @@ import { useRouter } from "next/navigation";
 import { initialsFromUser } from "@/lib/avatar";
 import { PaginationBar } from "./pagination/PaginationBar";
 import { DateCell } from "@/components/DateCell";
+import { ElapsedDaysCell } from "@/components/ElapsedDaysCell";
+import { formatGTDateTime } from "@/lib/date";
 import type { PageEnvelope } from "@/lib/pagination";
 
 interface DocumentsTableProps {
@@ -208,6 +210,7 @@ export function DocumentsTable({
           <TableBody>
             {documents.map((doc) => {
               const users = doc.assignedUsers ?? [];
+              const sendDateTooltip = formatGTDateTime(doc.sendDate, { ampm: "upper" });
               return (
                 <TableRow key={doc.id}>
                   <TableCell className="font-medium">
@@ -230,7 +233,10 @@ export function DocumentsTable({
                     </Badge>
                   </TableCell>
                   <TableCell className="text-center">
-                    {doc.businessDays}
+                    <ElapsedDaysCell
+                      fromISO={doc.sendDate}
+                      title={sendDateTooltip ? `${sendDateTooltip} GT` : undefined}
+                    />
                   </TableCell>
                   <TableCell>
                     <button

--- a/src/components/supervision-table.tsx
+++ b/src/components/supervision-table.tsx
@@ -11,6 +11,8 @@ import { Button } from './ui/button';
 import type { SupervisionDoc, DocEstado } from '@/services/documentsService';
 import { PaginationBar } from './pagination/PaginationBar';
 import type { PageEnvelope } from '@/lib/pagination';
+import { ElapsedDaysCell } from '@/components/ElapsedDaysCell';
+import { formatGTDateTime } from '@/lib/date';
 
 interface SupervisionTableProps {
   data?: PageEnvelope<SupervisionDoc>;
@@ -150,17 +152,25 @@ export function SupervisionTable({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {documents.map((d) => (
-              <TableRow key={d.id}>
-                <TableCell className="font-medium">{d.titulo}</TableCell>
-                <TableCell className="text-muted-foreground">{d.empresa?.nombre ?? ''}</TableCell>
-                <TableCell>
-                  <Badge className={cn('border', getStatusClass(d.estado))}>{d.estado}</Badge>
-                </TableCell>
-                <TableCell>{d.diasTranscurridos ?? 0}</TableCell>
-                <TableCell className="text-muted-foreground">{d.descripcionEstado ?? ''}</TableCell>
-              </TableRow>
-            ))}
+            {documents.map((d) => {
+              const addDateTooltip = formatGTDateTime(d.addDate, { ampm: 'upper' });
+              return (
+                <TableRow key={d.id}>
+                  <TableCell className="font-medium">{d.titulo}</TableCell>
+                  <TableCell className="text-muted-foreground">{d.empresa?.nombre ?? ''}</TableCell>
+                  <TableCell>
+                    <Badge className={cn('border', getStatusClass(d.estado))}>{d.estado}</Badge>
+                  </TableCell>
+                  <TableCell>
+                    <ElapsedDaysCell
+                      fromISO={d.addDate ?? undefined}
+                      title={addDateTooltip ? `${addDateTooltip} GT` : undefined}
+                    />
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{d.descripcionEstado ?? ''}</TableCell>
+                </TableRow>
+              );
+            })}
             {!loading && documents.length === 0 && (
               <TableRow>
                 <TableCell colSpan={5} className="text-center py-4 text-sm text-muted-foreground">

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,5 +1,12 @@
 const GT_TZ = 'America/Guatemala';
 
+const dayFormatterGT = new Intl.DateTimeFormat('es-GT', {
+  timeZone: GT_TZ,
+  day: '2-digit',
+  month: '2-digit',
+  year: 'numeric',
+});
+
 function toDate(input?: string | Date | null) {
   if (!input) return null;
   return typeof input === 'string' ? new Date(input) : input;
@@ -8,12 +15,7 @@ function toDate(input?: string | Date | null) {
 export function formatGT(input?: string | Date | null) {
   const d = toDate(input);
   if (!d) return '';
-  return new Intl.DateTimeFormat('es-GT', {
-    timeZone: GT_TZ,
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  }).format(d);
+  return dayFormatterGT.format(d);
 }
 
 export function formatGTDateTime(
@@ -44,4 +46,40 @@ export function formatGTDateTime(
 export function getTime(input?: string | Date | null) {
   const d = toDate(input);
   return d ? d.getTime() : 0;
+}
+
+function toStartOfDayISOStringGT(input: Date) {
+  const parts = dayFormatterGT.formatToParts(input);
+  const year = parts.find((p) => p.type === 'year')?.value;
+  const month = parts.find((p) => p.type === 'month')?.value;
+  const day = parts.find((p) => p.type === 'day')?.value;
+  if (!year || !month || !day) return null;
+  return `${year}-${month}-${day}T00:00:00Z`;
+}
+
+// Devuelve un Date en start-of-day de Guatemala
+export function startOfDayGT(d: Date | string | number): Date {
+  const base = new Date(d);
+  if (Number.isNaN(base.getTime())) {
+    return new Date(NaN);
+  }
+  const iso = toStartOfDayISOStringGT(base);
+  return iso ? new Date(iso) : new Date(NaN);
+}
+
+const MS_IN_DAY = 86_400_000;
+
+// Diferencia de días calendario (floor) en zona GT
+export function elapsedDaysGT(fromISO: string | Date, now: Date = new Date()): number {
+  const from = startOfDayGT(fromISO);
+  const current = startOfDayGT(now);
+  if (Number.isNaN(from.getTime()) || Number.isNaN(current.getTime())) {
+    return 0;
+  }
+  return Math.floor((current.getTime() - from.getTime()) / MS_IN_DAY);
+}
+
+// Devuelve "0 días" | "1 día" | "N días"
+export function formatElapsedDaysLabel(days: number): string {
+  return `${days} ${days === 1 ? 'día' : 'días'}`;
 }


### PR DESCRIPTION
## Summary
- add Guatemala-specific helpers to compute elapsed calendar days
- create an ElapsedDaysCell component that shows the days label with a tooltip
- integrate the elapsed days cell into the documents and supervision tables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd034bdc208332a204be6a20b164e9