### PR TITLE
Implement merged PDF download in document detail

### DIFF
--- a/src/services/documentsService.ts
+++ b/src/services/documentsService.ts
@@ -418,6 +418,23 @@ export async function getDocumentDetail(id: number): Promise<DocumentDetail> {
   };
 }
 
+export async function fetchMergedPdf(
+  cuadroFirmasId: number,
+  opts?: { download?: boolean; signal?: AbortSignal },
+) {
+  const qs = opts?.download ? '?download=1' : '';
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_API_BASE_URL}/api/documents/cuadro-firmas/${cuadroFirmasId}/merged-pdf${qs}`,
+    {
+      method: 'GET',
+      credentials: 'include',
+      signal: opts?.signal,
+    },
+  );
+  if (!res.ok) throw new Error('No se pudo generar el PDF unificado');
+  return await res.blob();
+}
+
 export { getDocumentsByUser as getDocsByUser };
 
 export async function signDocument(payload: {


### PR DESCRIPTION
## Summary
- add a documents service helper to request the merged PDF from the new backend endpoint
- update the document detail download button to request the merged PDF, open it in a new tab, or force download when needed
- provide UI feedback for the download action with a spinner, dropdown option, and error toasts

## Testing
- npm run lint
- npm run typecheck *(fails: pre-existing type error in src/app/general/page.tsx:107)*

------
https://chatgpt.com/codex/tasks/task_e_68cd0935cbb483329e5b3180e21fe55a