### PR TITLE
Fix date parsing in document supervision views

### DIFF
--- a/README_NOTE.md
+++ b/README_NOTE.md
@@ -1,0 +1,3 @@
+# Notas de seguimiento
+
+- Recomendación: estandarizar las respuestas del backend a fechas en formato ISO 8601 para simplificar el formateo en el frontend. Mientras tanto, el helper `parseGTDate` se encarga de manejar los formatos mixtos actuales.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "next build",
     "start": "next start -p 9002",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --import tsx --test src/lib/date.test.ts"
   },
   "dependencies": {
     "@genkit-ai/googleai": "^1.14.1",

--- a/src/components/DateCell.tsx
+++ b/src/components/DateCell.tsx
@@ -2,12 +2,14 @@
 import React from 'react';
 import { formatGT, formatGTDateTime } from '@/lib/date';
 
-export function DateCell({
-  value,
-  withTime = false,
-  ampm = 'upper',
-}: { value?: string | Date | null; withTime?: boolean; ampm?: 'upper' | 'locale' }) {
-  const shown = withTime ? formatGTDateTime(value, { ampm }) : formatGT(value);
-  const title = formatGTDateTime(value, { ampm: 'upper' }) || '';
-  return <span title={title}>{shown || '—'}</span>;
+type DateCellProps = {
+  value?: string | number | Date | null;
+  withTime?: boolean;
+};
+
+export function DateCell({ value, withTime = false }: DateCellProps) {
+  const shown = withTime ? formatGTDateTime(value) : formatGT(value);
+  const titleValue = formatGTDateTime(value);
+  const title = titleValue === '—' ? undefined : titleValue;
+  return <span title={title}>{shown}</span>;
 }

--- a/src/components/ElapsedDaysCell.tsx
+++ b/src/components/ElapsedDaysCell.tsx
@@ -15,8 +15,8 @@ export function ElapsedDaysCell({ fromISO, title }: Props) {
 
   const days = elapsedDaysGT(fromISO);
   const label = formatElapsedDaysLabel(days);
-  const formatted = formatGTDateTime(fromISO, { ampm: 'upper' });
-  const tooltip = title ?? (formatted ? `${formatted} GT` : label);
+  const formatted = formatGTDateTime(fromISO);
+  const tooltip = title ?? (formatted !== '—' ? `${formatted} GT` : label);
 
   return (
     <Tooltip>

--- a/src/components/documents-table.tsx
+++ b/src/components/documents-table.tsx
@@ -210,7 +210,9 @@ export function DocumentsTable({
           <TableBody>
             {documents.map((doc) => {
               const users = doc.assignedUsers ?? [];
-              const sendDateTooltip = formatGTDateTime(doc.sendDate, { ampm: "upper" });
+              const sendDateTooltip = formatGTDateTime(doc.sendDate);
+              const sendDateTitle =
+                sendDateTooltip !== "—" ? `${sendDateTooltip} GT` : undefined;
               return (
                 <TableRow key={doc.id}>
                   <TableCell className="font-medium">
@@ -235,7 +237,7 @@ export function DocumentsTable({
                   <TableCell className="text-center">
                     <ElapsedDaysCell
                       fromISO={doc.sendDate}
-                      title={sendDateTooltip ? `${sendDateTooltip} GT` : undefined}
+                      title={sendDateTitle}
                     />
                   </TableCell>
                   <TableCell>

--- a/src/components/supervision-table.tsx
+++ b/src/components/supervision-table.tsx
@@ -153,7 +153,8 @@ export function SupervisionTable({
           </TableHeader>
           <TableBody>
             {documents.map((d) => {
-              const addDateTooltip = formatGTDateTime(d.addDate, { ampm: 'upper' });
+              const addDateTooltip = formatGTDateTime(d.addDate);
+              const addDateTitle = addDateTooltip !== '—' ? `${addDateTooltip} GT` : undefined;
               return (
                 <TableRow key={d.id}>
                   <TableCell className="font-medium">{d.titulo}</TableCell>
@@ -164,7 +165,7 @@ export function SupervisionTable({
                   <TableCell>
                     <ElapsedDaysCell
                       fromISO={d.addDate ?? undefined}
-                      title={addDateTooltip ? `${addDateTooltip} GT` : undefined}
+                      title={addDateTitle}
                     />
                   </TableCell>
                   <TableCell className="text-muted-foreground">{d.descripcionEstado ?? ''}</TableCell>

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { formatGTDateTime, parseGTDate } from './date';
+
+const ISO_SAMPLE = '2025-09-19T19:52:47.067Z';
+const WITH_COMMA_SAMPLE = '19/09/2025, 13:50:07';
+const NO_COMMA_SAMPLE = '19/09/2025 13:50:07';
+const DATE_ONLY_SAMPLE = '19/09/2025';
+
+test('parseGTDate parses ISO 8601 strings', () => {
+  const parsed = parseGTDate(ISO_SAMPLE);
+  assert.ok(parsed);
+  assert.equal(parsed?.toISOString(), ISO_SAMPLE);
+});
+
+test('parseGTDate parses dd/MM/yyyy, HH:mm:ss strings', () => {
+  const parsed = parseGTDate(WITH_COMMA_SAMPLE);
+  assert.ok(parsed);
+  assert.equal(formatGTDateTime(parsed, 'dd/MM/yyyy HH:mm:ss'), '19/09/2025 13:50:07');
+});
+
+test('parseGTDate parses dd/MM/yyyy HH:mm:ss strings', () => {
+  const parsed = parseGTDate(NO_COMMA_SAMPLE);
+  assert.ok(parsed);
+  assert.equal(formatGTDateTime(parsed, 'dd/MM/yyyy HH:mm:ss'), '19/09/2025 13:50:07');
+});
+
+test('parseGTDate parses dd/MM/yyyy strings', () => {
+  const parsed = parseGTDate(DATE_ONLY_SAMPLE);
+  assert.ok(parsed);
+  assert.equal(formatGTDateTime(parsed, 'dd/MM/yyyy HH:mm'), '19/09/2025 00:00');
+});
+
+test('parseGTDate returns null for empty input', () => {
+  assert.equal(parseGTDate(''), null);
+  assert.equal(parseGTDate('   '), null);
+});
+
+test('parseGTDate returns null for nullish values', () => {
+  assert.equal(parseGTDate(null), null);
+  assert.equal(parseGTDate(undefined), null);
+});
+
+test('formatGTDateTime returns formatted value', () => {
+  assert.equal(formatGTDateTime(ISO_SAMPLE), '19/09/2025 19:52');
+});
+
+test('formatGTDateTime returns placeholder for invalid values', () => {
+  assert.equal(formatGTDateTime('invalid-date'), '—');
+  assert.equal(formatGTDateTime(undefined), '—');
+});


### PR DESCRIPTION
## Summary
- add a resilient `parseGTDate` helper to support ISO and dd/MM/yyyy payloads and reuse it across date formatters
- adjust date-related table cells to show a fallback em dash when the API sends unparsable values and avoid Invalid Date errors
- cover the helper with a lightweight node:test suite and document the backend ISO recommendation

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1b48b583c8332b12c0636083fcbd7