### PR TITLE
Implement document tabs and AI summary workflow

### DIFF
--- a/src/app/general/page.tsx
+++ b/src/app/general/page.tsx
@@ -78,6 +78,20 @@ export default function GeneralPage() {
     const start = (currentPage - 1) * pageSize;
     const paginatedDocuments = filteredDocuments.slice(start, start + pageSize);
 
+    const tableData = useMemo(
+        () => ({
+            items: paginatedDocuments,
+            total,
+            pages: totalPages,
+            page: currentPage,
+            limit: pageSize,
+            sort: sortOrder,
+            hasPrev: currentPage > 1,
+            hasNext: currentPage < totalPages,
+        }),
+        [paginatedDocuments, total, totalPages, currentPage, pageSize, sortOrder],
+    );
+
     const statusCounts = useMemo(() => {
         return filteredDocuments.reduce(
             (acc, doc) => {
@@ -104,7 +118,7 @@ export default function GeneralPage() {
     return (
         <div className="h-full">
             <DocumentsTable
-                items={paginatedDocuments}
+                data={tableData}
                 title="Mis Documentos"
                 description="Documentos asignados a usted para revisar y firmar."
                 searchTerm={searchTerm}
@@ -114,12 +128,6 @@ export default function GeneralPage() {
                 sortOrder={sortOrder}
                 onSortToggle={() => setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'))}
                 statusCounts={statusCounts}
-                total={total}
-                pages={totalPages}
-                hasPrev={currentPage > 1}
-                hasNext={currentPage < totalPages}
-                page={currentPage}
-                limit={pageSize}
                 onPageChange={setPage}
                 onLimitChange={(size) => {
                     setPageSize(size);

--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronDown, Loader2, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+
+import { PDFViewer } from "./PDFViewer";
+
+type TabValue = "firmas" | "original";
+
+type SummaryStatus = "idle" | "success" | "error";
+
+type SaveStatus = "idle" | "saving" | "success" | "error";
+
+type DocumentTabsProps = {
+  urlCuadroFirmasPDF?: string | null;
+  urlDocumento?: string | null;
+  onRefreshLinks: () => Promise<void>;
+  isRefreshingLinks?: boolean;
+  onSummarize?: () => Promise<void> | void;
+  summarizing?: boolean;
+  summaryStatus?: SummaryStatus;
+  summaryError?: string | null;
+  summaryText?: string | null;
+  onSaveSummary?: () => Promise<void> | void;
+  saveStatus?: SaveStatus;
+};
+
+export function DocumentTabs({
+  urlCuadroFirmasPDF,
+  urlDocumento,
+  onRefreshLinks,
+  isRefreshingLinks = false,
+  onSummarize,
+  summarizing = false,
+  summaryStatus = "idle",
+  summaryError = null,
+  summaryText = null,
+  onSaveSummary,
+  saveStatus = "idle",
+}: DocumentTabsProps) {
+  const [activeTab, setActiveTab] = useState<TabValue>("firmas");
+  const [summaryOpen, setSummaryOpen] = useState(false);
+
+  useEffect(() => {
+    if (summaryText) {
+      setSummaryOpen(true);
+    }
+  }, [summaryText]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!event.altKey) return;
+      if (event.key === "1") {
+        event.preventDefault();
+        setActiveTab("firmas");
+      }
+      if (event.key === "2") {
+        event.preventDefault();
+        setActiveTab("original");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  useEffect(() => {
+    if (summaryStatus === "success" && activeTab !== "original") {
+      setActiveTab("original");
+    }
+  }, [summaryStatus, activeTab]);
+
+  const summaryHelperText = useMemo(() => {
+    if (summaryStatus === "success") {
+      return "Resumen generado correctamente.";
+    }
+    if (summaryStatus === "error" && summaryError) {
+      return summaryError;
+    }
+    return null;
+  }, [summaryError, summaryStatus]);
+
+  const saveHelperText = useMemo(() => {
+    if (saveStatus === "success") {
+      return "Resumen guardado exitosamente.";
+    }
+    if (saveStatus === "error") {
+      return "No se pudo guardar el resumen.";
+    }
+    return null;
+  }, [saveStatus]);
+
+  const handleTabChange = (value: string) => {
+    setActiveTab(value as TabValue);
+  };
+
+  return (
+    <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
+      <div className="sticky top-0 z-20 mb-3 bg-background/90 pb-1 pt-2 backdrop-blur">
+        <TabsList className="grid h-auto w-full grid-cols-2 gap-2 rounded-lg bg-muted p-1 text-xs font-medium sm:text-sm">
+          <TabsTrigger value="firmas" className="rounded-md px-2 py-2">
+            Cuadro de firmas
+          </TabsTrigger>
+          <TabsTrigger value="original" className="rounded-md px-2 py-2">
+            Documento original
+          </TabsTrigger>
+        </TabsList>
+      </div>
+
+      <TabsContent value="firmas" className="mt-0 space-y-4">
+        <PDFViewer
+          title="Cuadro de firmas"
+          src={urlCuadroFirmasPDF ?? undefined}
+          onRefresh={onRefreshLinks}
+          isRefreshing={isRefreshingLinks}
+        />
+      </TabsContent>
+
+      <TabsContent value="original" className="mt-0 space-y-4">
+        <PDFViewer
+          title="Documento original"
+          src={urlDocumento ?? undefined}
+          onRefresh={onRefreshLinks}
+          isRefreshing={isRefreshingLinks}
+        />
+
+        <Card className="space-y-4 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <Sparkles className="mt-0.5 h-4 w-4 text-primary" aria-hidden="true" />
+              <div>
+                <h3 className="font-medium">Resumen con IA</h3>
+                <p className="text-sm text-muted-foreground">
+                  Genera un resumen ejecutivo del documento original.
+                </p>
+              </div>
+            </div>
+            <Button
+              onClick={() => onSummarize && onSummarize()}
+              disabled={summarizing || !onSummarize}
+              className="sm:w-auto"
+            >
+              {summarizing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  Resumiendo...
+                </>
+              ) : (
+                "Resumir documento"
+              )}
+            </Button>
+          </div>
+
+          {summaryHelperText && (
+            <p
+              className={cn("text-sm", summaryStatus === "error" ? "text-destructive" : "text-muted-foreground")}
+              role="status"
+            >
+              {summaryHelperText}
+            </p>
+          )}
+
+          {summaryText ? (
+            <Collapsible open={summaryOpen} onOpenChange={setSummaryOpen} className="space-y-3">
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" className="flex w-full items-center justify-between">
+                  <span>Ver resumen generado</span>
+                  <ChevronDown
+                    className={cn(
+                      "h-4 w-4 transition-transform",
+                      summaryOpen ? "rotate-180" : "rotate-0",
+                    )}
+                    aria-hidden="true"
+                  />
+                </Button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="space-y-3">
+                <div className="rounded-lg border bg-muted/40 p-4 text-sm leading-relaxed text-muted-foreground">
+                  {summaryText}
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+                  {saveHelperText && (
+                    <p
+                      className={cn(
+                        "text-sm", saveStatus === "error" ? "text-destructive" : "text-muted-foreground",
+                      )}
+                      role="status"
+                    >
+                      {saveHelperText}
+                    </p>
+                  )}
+                  <Button
+                    variant="outline"
+                    onClick={() => onSaveSummary && onSaveSummary()}
+                    disabled={!onSaveSummary || saveStatus === "saving"}
+                  >
+                    {saveStatus === "saving" ? (
+                      <>
+                        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                        Guardando...
+                      </>
+                    ) : (
+                      "Guardar resumen"
+                    )}
+                  </Button>
+                </div>
+              </CollapsibleContent>
+            </Collapsible>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              El resumen aparecerá aquí cuando se genere.
+            </p>
+          )}
+        </Card>
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+export default DocumentTabs;

--- a/src/components/document/PDFViewer.tsx
+++ b/src/components/document/PDFViewer.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, RefreshCcw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type PDFViewerStatus = "idle" | "loading" | "success" | "failed" | "empty";
+
+type PDFViewerProps = {
+  src?: string | null;
+  title?: string;
+  className?: string;
+  /** Callback that refreshes the presigned URL links */
+  onRefresh?: () => Promise<void> | void;
+  /** Indicates whether the parent component is already refreshing the links */
+  isRefreshing?: boolean;
+  /**
+   * Time in milliseconds to wait before declaring the iframe failed.
+   * Defaults to 6000ms.
+   */
+  timeoutMs?: number;
+};
+
+export function PDFViewer({
+  src,
+  title,
+  className,
+  onRefresh,
+  isRefreshing = false,
+  timeoutMs = 6000,
+}: PDFViewerProps) {
+  const [status, setStatus] = useState<PDFViewerStatus>(() => (!src ? "empty" : "loading"));
+  const timeoutRef = useRef<number>();
+  const autoRefreshRef = useRef(false);
+
+  useEffect(() => {
+    if (!src) {
+      setStatus("empty");
+      return;
+    }
+
+    setStatus("loading");
+    autoRefreshRef.current = false;
+
+    timeoutRef.current = window.setTimeout(() => {
+      setStatus((prev) => {
+        if (prev === "loading") {
+          if (onRefresh && !autoRefreshRef.current) {
+            autoRefreshRef.current = true;
+            void Promise.resolve(onRefresh()).catch(() => undefined);
+          }
+          return "failed";
+        }
+        return prev;
+      });
+    }, timeoutMs);
+
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, [onRefresh, src, timeoutMs]);
+
+  const handleLoad = useCallback(() => {
+    if (timeoutRef.current) {
+      window.clearTimeout(timeoutRef.current);
+    }
+    setStatus("success");
+  }, []);
+
+  const handleManualRefresh = useCallback(async () => {
+    if (!onRefresh) return;
+    setStatus("loading");
+    autoRefreshRef.current = true;
+    try {
+      await onRefresh();
+    } catch (error) {
+      setStatus("failed");
+    }
+  }, [onRefresh]);
+
+  const containerClass = cn(
+    "relative w-full h-[60vh] md:h-[78vh] rounded-xl border bg-background overflow-hidden",
+    className,
+  );
+
+  if (status === "empty") {
+    return (
+      <div className={containerClass}>
+        <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
+          Sin vista disponible
+        </div>
+      </div>
+    );
+  }
+
+  if (status === "failed") {
+    return (
+      <div className={containerClass}>
+        <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
+          <p className="text-sm text-muted-foreground">No se pudo cargar el PDF.</p>
+          {onRefresh && (
+            <Button
+              variant="outline"
+              onClick={handleManualRefresh}
+              disabled={isRefreshing}
+              className="flex items-center gap-2"
+            >
+              {isRefreshing ? (
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+              )}
+              Actualizar vínculo
+            </Button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={containerClass}>
+      <iframe
+        title={title ?? "Visor de PDF"}
+        src={src ?? undefined}
+        className="h-full w-full"
+        referrerPolicy="no-referrer"
+        onLoad={handleLoad}
+        onError={() => setStatus("failed")}
+      />
+      {status === "loading" && (
+        <div className="absolute inset-0 flex items-center justify-center bg-background/80" aria-live="polite">
+          <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
+            <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+            <span>{isRefreshing ? "Actualizando vínculo..." : "Cargando documento..."}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PDFViewer;


### PR DESCRIPTION
## Summary
- add a DocumentTabs component that toggles between Cuadro de firmas and Documento original, includes keyboard shortcuts, and surfaces the AI summary card only for the original document
- introduce a reusable PDFViewer with retry/refresh handling for expiring presigned URLs and integrate it into the document detail page
- wire the document detail view to refresh links, call the summary endpoints, and adjust the general listing page to provide typed pagination data for the documents table

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1c5f2eac48332b721af68b12f32bb