### PR TITLE
Refactor websocket initialization flow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
 import { ReactQueryProvider } from "@/lib/react-query";
 
-import AuthenticatedWebsocketProvider from "@/context/AuthenticatedWebsocketProvider";
+import { WebsocketProvider } from "@/context/WebsocketContext";
 import { NotificationsProvider } from "@/components/notifications/NotificationsProvider";
 
 export const metadata: Metadata = {
@@ -33,7 +33,7 @@ export default function RootLayout({
       </head>
       <body className="font-body antialiased min-h-screen flex flex-col">
         <ReactQueryProvider>
-          <AuthenticatedWebsocketProvider>
+          <WebsocketProvider>
             <NotificationsProvider>
               <main className="flex-grow">{children}</main>
             </NotificationsProvider>
@@ -44,7 +44,7 @@ export default function RootLayout({
               </div>
             </footer>
             <Toaster />
-          </AuthenticatedWebsocketProvider>
+          </WebsocketProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,13 +19,13 @@ export default function Home() {
       <div className="absolute inset-0 bg-black/50 -z-10"></div>
       <Card className="w-full max-w-md glassmorphism">
         <CardHeader className="text-center p-6">
-           <Image 
-            src="/genesissign.png" 
+          <Image
+            src="/genesissign.png"
             alt="Génesis Sign Logotipo"
-            width={250}
+            width={200}
             height={80}
             className="mx-auto mb-4"
-            style={{ width: '250px', height: 'auto' }}
+            style={{ height: "auto" }}
           />
         </CardHeader>
         <CardContent>

--- a/src/lib/tokenStore.ts
+++ b/src/lib/tokenStore.ts
@@ -8,9 +8,11 @@ function notify(token: string | null) {
   listeners.forEach((listener) => listener(token));
 }
 
-export function getToken() {
+export function getAccessToken() {
   return accessToken;
 }
+
+export const getToken = getAccessToken;
 
 export function setToken(t: string | null) {
   accessToken = t;


### PR DESCRIPTION
## Summary
- replace the websocket helper with a singleton configured for manual connection and reconnection
- update the websocket context to connect only after an access token is present while still rendering the layout immediately
- wrap the app with the websocket provider, expose token helpers, and fix the home logo image sizing warning

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4565713648332b79e0c4d6a9e6672