### PR TITLE
fix: refresh notifications menu states

### DIFF
--- a/src/services/notificationsService.ts
+++ b/src/services/notificationsService.ts
@@ -55,7 +55,10 @@ export async function getNotificationsByUser(
     `/documents/cuadro-firmas/notificaciones/${userId}${query}`,
   );
   const payload = response.data as any;
-  const arr = Array.isArray(payload) ? payload : payload?.items ?? [];
+  const arr =
+    Array.isArray(payload)
+      ? payload
+      : payload?.data?.items ?? payload?.items ?? [];
   return arr.map(adaptNotification);
 }
 


### PR DESCRIPTION
## Summary
- remove controlled open state from the notification dropdown so Radix manages visibility and refresh data on open
- keep menu interactions responsive by letting items close the dropdown naturally and ensuring the trigger button type is button
- fix notification service payload parsing to read nested data.items collections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4682bd4608332ac05ee6c78d4ebd7