### PR TITLE
feat: replace notification popover with headless component

### DIFF
--- a/src/components/notifications/NotificationBell.tsx
+++ b/src/components/notifications/NotificationBell.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Bell, Loader2, Check, MailOpen } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import { useToast } from "@/hooks/use-toast";
@@ -14,6 +13,7 @@ import { useAuth } from "@/store/auth";
 import { useNotifications } from "@/store/notifications";
 import { timeAgo } from "@/lib/time";
 import type { UINotification } from "@/services/notificationsService";
+import { HeadlessPopover } from "@/components/ui/HeadlessPopover";
 
 export function NotificationBell() {
   const { currentUser } = useAuth();
@@ -31,6 +31,7 @@ export function NotificationBell() {
   const { toast } = useToast();
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   const count = unreadCount;
   const badge = useMemo(
@@ -77,123 +78,122 @@ export function NotificationBell() {
 
   const handleOpenChange = (next: boolean) => {
     setOpen(next);
-    if (next) {
-      void fetch({ silent: true, userId: currentUser?.id });
-    }
+    if (next) void fetch({ silent: true, userId: currentUser?.id });
   };
 
   return (
-    <Popover open={open} onOpenChange={handleOpenChange}>
-      <PopoverTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          aria-label="Ver notificaciones"
-          className="relative rounded-full pointer-events-auto"
-          data-testid="notification-bell"
-        >
-          <Bell className="h-5 w-5" aria-hidden="true" />
-          {badge && (
-            <span
-              aria-label={`${badge} notificaciones sin leer`}
-              className="absolute -right-0 -top-0 min-w-[1.25rem] rounded-full bg-primary px-1.5 text-[10px] font-bold leading-4 text-primary-foreground"
-            >
-              {badge}
-            </span>
-          )}
-        </Button>
-      </PopoverTrigger>
+    <>
+      <Button
+        ref={triggerRef}
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label="Ver notificaciones"
+        className="relative rounded-full pointer-events-auto"
+        data-testid="notification-bell"
+        onClick={() => handleOpenChange(!open)}
+      >
+        <Bell className="h-5 w-5" aria-hidden="true" />
+        {badge && (
+          <span
+            aria-label={`${badge} notificaciones sin leer`}
+            className="absolute -right-0 -top-0 min-w-[1.25rem] rounded-full bg-primary px-1.5 text-[10px] font-bold leading-4 text-primary-foreground"
+          >
+            {badge}
+          </span>
+        )}
+      </Button>
 
-      <PopoverContent
-        align="end"
-        sideOffset={8}
+      <HeadlessPopover
+        open={open}
+        onOpenChange={handleOpenChange}
+        anchorRef={triggerRef}
+        width={384}
+        offset={8}
         className="z-[1000] w-96 overflow-hidden rounded-xl border bg-popover p-0 shadow-xl"
       >
         <div className="flex max-h-[60vh] flex-col" role="region" aria-live="polite">
-            <div className="flex items-center justify-between px-4 py-3">
-              <p className="p-0 text-base font-medium">Notificaciones</p>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleMarkAll}
-                disabled={loadingAction || count === 0}
-              >
-                {loadingAction ? (
-                  <Loader2 className="mr-1 h-4 w-4 animate-spin" aria-hidden="true" />
-                ) : (
-                  <Check className="mr-1 h-4 w-4" aria-hidden="true" />
-                )}
-                Marcar todas
-              </Button>
-            </div>
-            <Separator />
-
-            <ScrollArea className="max-h-[50vh] min-h-[200px]">
-              {loading ? (
-                <div className="p-6 text-center text-sm text-muted-foreground">Cargando…</div>
-              ) : error ? (
-                <div className="flex flex-col items-center gap-2 p-6 text-center text-sm text-muted-foreground">
-                  <p className="text-destructive">No se pudieron cargar las notificaciones.</p>
-                  <Button variant="link" size="sm" onClick={handleRefresh}>
-                    Reintentar
-                  </Button>
-                </div>
-              ) : items.length === 0 ? (
-                <div className="flex flex-col items-center gap-2 p-6 text-center text-sm text-muted-foreground">
-                  <p>Sin notificaciones</p>
-                  <Button variant="link" size="sm" onClick={handleRefresh}>
-                    Actualizar
-                  </Button>
-                </div>
+          <div className="flex items-center justify-between px-4 py-3">
+            <p className="p-0 text-base font-medium">Notificaciones</p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleMarkAll}
+              disabled={loadingAction || count === 0}
+            >
+              {loadingAction ? (
+                <Loader2 className="mr-1 h-4 w-4 animate-spin" aria-hidden="true" />
               ) : (
-                <ul className="py-1">
-                  {items.map((n) => (
-                    <li key={n.id}>
-                      <button
-                        type="button"
-                        className="w-full px-2 text-left hover:bg-muted/60 focus:bg-muted/60 focus-visible:bg-muted/60 focus-visible:outline-none"
-                        onClick={async () => {
-                          setOpen(false);
-                          await handleItemSelect(n);
-                        }}
-                      >
-                        <div className="flex items-start gap-3 py-1">
-                          <div className="mt-0.5 text-muted-foreground" aria-hidden="true">
-                            {n.isRead ? <MailOpen className="h-4 w-4" /> : <Bell className="h-4 w-4" />}
-                          </div>
-                          <div className="min-w-0 flex-1">
-                            <p className={`truncate text-sm ${n.isRead ? "text-muted-foreground" : "font-medium"}`}>
-                              {n.title}
-                            </p>
-                            {n.message ? (
-                              <p className="line-clamp-2 text-xs text-muted-foreground">{n.message}</p>
-                            ) : null}
-                            <p className="mt-0.5 text-[11px] text-muted-foreground">
-                              {timeAgo(n.createdAt)}
-                            </p>
-                          </div>
-                          {!n.isRead && (
-                            <Badge className="shrink-0" aria-label="Notificación nueva">
-                              Nuevo
-                            </Badge>
-                          )}
-                        </div>
-                      </button>
-                      <Separator />
-                    </li>
-                  ))}
-                </ul>
+                <Check className="mr-1 h-4 w-4" aria-hidden="true" />
               )}
-            </ScrollArea>
+              Marcar todas
+            </Button>
+          </div>
+          <Separator />
 
-            <div className="flex items-center justify-end gap-2 border-t px-4 py-3">
-              <Link href="/notificaciones" className="text-xs text-primary underline underline-offset-2">
-                Ver todas
-              </Link>
-            </div>
+          <ScrollArea className="max-h-[50vh] min-h-[200px]">
+            {loading ? (
+              <div className="p-6 text-center text-sm text-muted-foreground">Cargando…</div>
+            ) : error ? (
+              <div className="flex flex-col items-center gap-2 p-6 text-center text-sm text-muted-foreground">
+                <p className="text-destructive">No se pudieron cargar las notificaciones.</p>
+                <Button variant="link" size="sm" onClick={handleRefresh}>
+                  Reintentar
+                </Button>
+              </div>
+            ) : items.length === 0 ? (
+              <div className="flex flex-col items-center gap-2 p-6 text-center text-sm text-muted-foreground">
+                <p>Sin notificaciones</p>
+                <Button variant="link" size="sm" onClick={handleRefresh}>
+                  Actualizar
+                </Button>
+              </div>
+            ) : (
+              <ul className="py-1">
+                {items.map((n) => (
+                  <li key={n.id}>
+                    <button
+                      type="button"
+                      className="w-full px-2 text-left hover:bg-muted/60 focus:bg-muted/60 focus-visible:bg-muted/60 focus-visible:outline-none"
+                      onClick={async () => {
+                        setOpen(false);
+                        await handleItemSelect(n);
+                      }}
+                    >
+                      <div className="flex items-start gap-3 py-1">
+                        <div className="mt-0.5 text-muted-foreground" aria-hidden="true">
+                          {n.isRead ? <MailOpen className="h-4 w-4" /> : <Bell className="h-4 w-4" />}
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className={`truncate text-sm ${n.isRead ? "text-muted-foreground" : "font-medium"}`}>
+                            {n.title}
+                          </p>
+                          {n.message ? (
+                            <p className="line-clamp-2 text-xs text-muted-foreground">{n.message}</p>
+                          ) : null}
+                          <p className="mt-0.5 text-[11px] text-muted-foreground">{timeAgo(n.createdAt)}</p>
+                        </div>
+                        {!n.isRead && (
+                          <Badge className="shrink-0" aria-label="Notificación nueva">
+                            Nuevo
+                          </Badge>
+                        )}
+                      </div>
+                    </button>
+                    <Separator />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </ScrollArea>
+
+          <div className="flex items-center justify-end gap-2 border-t px-4 py-3">
+            <Link href="/notificaciones" className="text-xs text-primary underline underline-offset-2">
+              Ver todas
+            </Link>
+          </div>
         </div>
-      </PopoverContent>
-    </Popover>
+      </HeadlessPopover>
+    </>
   );
 }

--- a/src/components/ui/HeadlessPopover.tsx
+++ b/src/components/ui/HeadlessPopover.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+type HeadlessPopoverProps = {
+  open: boolean;
+  onOpenChange: (next: boolean) => void;
+  anchorRef: React.RefObject<HTMLElement>;
+  width?: number;
+  offset?: number;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function HeadlessPopover({
+  open,
+  onOpenChange,
+  anchorRef,
+  width = 384,
+  offset = 8,
+  className,
+  children,
+}: HeadlessPopoverProps) {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+  const [style, setStyle] = useState<React.CSSProperties>({});
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onOpenChange(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onOpenChange]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      const panel = panelRef.current;
+      const anchor = anchorRef.current;
+      if (!panel || !anchor) return;
+      const target = e.target as Node;
+      if (!panel.contains(target) && !anchor.contains(target)) {
+        onOpenChange(false);
+      }
+    };
+    document.addEventListener("mousedown", onDown, true);
+    return () => document.removeEventListener("mousedown", onDown, true);
+  }, [open, onOpenChange, anchorRef]);
+
+  const computePosition = () => {
+    const anchor = anchorRef.current;
+    if (!anchor) return;
+    const rect = anchor.getBoundingClientRect();
+    const vw = window.innerWidth;
+    const top = Math.round(rect.bottom + offset);
+    const left = Math.round(Math.min(Math.max(16, rect.right - width), vw - width - 16));
+    setStyle({
+      position: "fixed",
+      top,
+      left,
+      width,
+      zIndex: 1000,
+    });
+  };
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    computePosition();
+    const onResize = () => computePosition();
+    window.addEventListener("resize", onResize);
+    window.addEventListener("scroll", onResize, true);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("scroll", onResize, true);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  if (!mounted || !open) return null;
+  return createPortal(
+    <div ref={panelRef} role="dialog" aria-modal="false" className={className} style={style}>
+      {children}
+    </div>,
+    document.body,
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable headless popover component that renders in a portal and handles positioning and dismissal logic
- refactor the notification bell to use the new headless popover while preserving existing behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d473f4d18083328fdbaf3b5765878c