### PR TITLE
Align admin listings with includeInactive pagination

### DIFF
--- a/src/app/admin/page/page.tsx
+++ b/src/app/admin/page/page.tsx
@@ -18,9 +18,19 @@ import { usePaginationState } from '@/hooks/usePaginationState';
 import { pageDebug } from '@/lib/page-debug';
 
 export default function PageAdminPage() {
-  const [showInactive, setShowInactive] = useState(false);
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch, isUserPagingRef } = usePaginationState({
+  const {
+    page,
+    limit,
+    sort,
+    search,
+    includeInactive,
+    setPage,
+    setLimit,
+    setSearch,
+    setIncludeInactive,
+    isUserPagingRef,
+  } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
@@ -63,9 +73,9 @@ export default function PageAdminPage() {
   }, [searchInput, setPage, setSearch]);
 
   const pagesQuery = useQuery({
-    queryKey: ['pages', { page, limit, sort, search, showInactive }],
+    queryKey: ['pages', page, limit, sort, search, includeInactive],
     queryFn: async () => {
-      const params: GetPagesParams = { page, limit, sort, search, showInactive };
+      const params: GetPagesParams = { page, limit, sort, search, includeInactive };
       const result = await getPages(params);
       return result;
     },
@@ -173,23 +183,23 @@ export default function PageAdminPage() {
         onLimitChange={setLimit}
         searchTerm={searchInput}
         onSearchChange={setSearchInput}
-        showInactive={showInactive}
+        includeInactive={includeInactive}
         onToggleInactive={(checked) => {
-          setShowInactive(checked);
+          setIncludeInactive(checked);
           if (page !== 1) {
             if (isUserPagingRef.current) {
               pageDebug('src/app/admin/page/page.tsx:181:setPage(skip)', {
                 reason: 'userPaging',
                 from: page,
                 to: 1,
-                showInactive: checked,
+                includeInactive: checked,
               });
               return;
             }
             pageDebug('src/app/admin/page/page.tsx:189:setPage', {
               from: page,
               to: 1,
-              showInactive: checked,
+              includeInactive: checked,
             });
             setPage(1);
           }

--- a/src/app/admin/permission/page.tsx
+++ b/src/app/admin/permission/page.tsx
@@ -25,8 +25,8 @@ export default function PermissionPage() {
     const loadBase = async () => {
       try {
         const [{ items: rolesData }, { items: pagesData }] = await Promise.all([
-          getRoles({ page: 1, limit: 100, showInactive: true }),
-          getPages({ page: 1, limit: 200, showInactive: true }),
+          getRoles({ page: 1, limit: 100, includeInactive: true }),
+          getPages({ page: 1, limit: 200, includeInactive: true }),
         ]);
         setRoles(rolesData.filter(r => r.activo));
         setPages(pagesData.filter(p => p.activo));

--- a/src/app/admin/roles/page.tsx
+++ b/src/app/admin/roles/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { RolesTable } from '@/components/roles-table';
 import {
@@ -19,9 +19,19 @@ import { pageDebug } from '@/lib/page-debug';
 import type { RoleForm } from '@/components/role-form-modal';
 
 export default function RolesPage() {
-  const [showInactive, setShowInactive] = useState(false);
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch, isUserPagingRef } = usePaginationState({
+  const {
+    page,
+    limit,
+    sort,
+    search,
+    includeInactive,
+    setPage,
+    setLimit,
+    setSearch,
+    setIncludeInactive,
+    isUserPagingRef,
+  } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
@@ -64,9 +74,9 @@ export default function RolesPage() {
   }, [searchInput, setPage, setSearch]);
 
   const rolesQuery = useQuery({
-    queryKey: ['roles', { page, limit, sort, search, showInactive }],
+    queryKey: ['roles', page, limit, sort, search, includeInactive],
     queryFn: async () => {
-      const params: GetRolesParams = { page, limit, sort, search, showInactive };
+      const params: GetRolesParams = { page, limit, sort, search, includeInactive };
       const result = await getRoles(params);
       return result;
     },
@@ -201,23 +211,23 @@ export default function RolesPage() {
         onLimitChange={setLimit}
         searchTerm={searchInput}
         onSearchChange={setSearchInput}
-        showInactive={showInactive}
+        includeInactive={includeInactive}
         onToggleInactive={(checked) => {
-          setShowInactive(checked);
+          setIncludeInactive(checked);
           if (page !== 1) {
             if (isUserPagingRef.current) {
               pageDebug('src/app/admin/roles/page.tsx:209:setPage(skip)', {
                 reason: 'userPaging',
                 from: page,
                 to: 1,
-                showInactive: checked,
+                includeInactive: checked,
               });
               return;
             }
             pageDebug('src/app/admin/roles/page.tsx:217:setPage', {
               from: page,
               to: 1,
-              showInactive: checked,
+              includeInactive: checked,
             });
             setPage(1);
           }

--- a/src/app/admin/usuarios/page.tsx
+++ b/src/app/admin/usuarios/page.tsx
@@ -19,7 +19,18 @@ import { pageDebug } from '@/lib/page-debug';
 
 export default function UsuariosPage() {
   const { toast } = useToast();
-  const { page, limit, sort, search, setPage, setLimit, setSearch, isUserPagingRef } = usePaginationState({
+  const {
+    page,
+    limit,
+    sort,
+    search,
+    includeInactive,
+    setPage,
+    setLimit,
+    setSearch,
+    setIncludeInactive,
+    isUserPagingRef,
+  } = usePaginationState({
     defaultLimit: 10,
     defaultSort: 'desc',
   });
@@ -62,9 +73,9 @@ export default function UsuariosPage() {
   }, [searchInput, setPage, setSearch]);
 
   const usersQuery = useQuery({
-    queryKey: ['users', { page, limit, sort, search }],
+    queryKey: ['users', page, limit, sort, search, includeInactive],
     queryFn: async () => {
-      const params: GetUsersParams = { page, limit, sort, search };
+      const params: GetUsersParams = { page, limit, sort, search, includeInactive };
       const result = await getUsers(params);
       return result;
     },
@@ -150,6 +161,27 @@ export default function UsuariosPage() {
       onLimitChange={setLimit}
       searchTerm={searchInput}
       onSearchChange={setSearchInput}
+      includeInactive={includeInactive}
+      onToggleInactive={(checked) => {
+        setIncludeInactive(checked);
+        if (page !== 1) {
+          if (isUserPagingRef.current) {
+            pageDebug('src/app/admin/usuarios/page.tsx:130:setPage(skip)', {
+              reason: 'userPaging',
+              from: page,
+              to: 1,
+              includeInactive: checked,
+            });
+            return;
+          }
+          pageDebug('src/app/admin/usuarios/page.tsx:138:setPage', {
+            from: page,
+            to: 1,
+            includeInactive: checked,
+          });
+          setPage(1);
+        }
+      }}
       onSaveUser={handleSaveUser}
       onDeleteUser={handleDeleteUser}
       loading={usersQuery.isFetching}

--- a/src/components/pages-table.tsx
+++ b/src/components/pages-table.tsx
@@ -21,7 +21,7 @@ interface PagesTableProps {
   onLimitChange: (limit: number) => void;
   searchTerm: string;
   onSearchChange: (value: string) => void;
-  showInactive: boolean;
+  includeInactive: boolean;
   onToggleInactive: (checked: boolean) => void;
   onSavePage: (page: PageForm) => Promise<void>;
   onDeletePage: (id: number) => Promise<void> | void;
@@ -35,7 +35,7 @@ export function PagesTable({
   onLimitChange,
   searchTerm,
   onSearchChange,
-  showInactive,
+  includeInactive,
   onToggleInactive,
   onSavePage,
   onDeletePage,
@@ -88,8 +88,8 @@ export function PagesTable({
                 />
               </div>
               <div className="flex items-center space-x-2">
-                <Switch id="show-inactive" checked={showInactive} onCheckedChange={onToggleInactive} />
-                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Ver inactivos</label>
+                <Switch id="show-inactive" checked={includeInactive} onCheckedChange={onToggleInactive} />
+                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Mostrar inactivos</label>
               </div>
               <Button onClick={() => openModal()}>
                 <Plus className="mr-2 h-4 w-4" />

--- a/src/components/roles-table.tsx
+++ b/src/components/roles-table.tsx
@@ -21,7 +21,7 @@ interface RolesTableProps {
   onLimitChange: (limit: number) => void;
   searchTerm: string;
   onSearchChange: (value: string) => void;
-  showInactive: boolean;
+  includeInactive: boolean;
   onToggleInactive: (checked: boolean) => void;
   onSaveRole: (role: RoleForm) => Promise<void>;
   onDeleteRole: (id: string) => Promise<void> | void;
@@ -35,7 +35,7 @@ export function RolesTable({
   onLimitChange,
   searchTerm,
   onSearchChange,
-  showInactive,
+  includeInactive,
   onToggleInactive,
   onSaveRole,
   onDeleteRole,
@@ -88,8 +88,8 @@ export function RolesTable({
                 />
               </div>
               <div className="flex items-center space-x-2">
-                <Switch id="show-inactive" checked={showInactive} onCheckedChange={onToggleInactive} />
-                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Ver inactivos</label>
+                <Switch id="show-inactive" checked={includeInactive} onCheckedChange={onToggleInactive} />
+                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Mostrar inactivos</label>
               </div>
               <Button onClick={() => openModal()}>
                 <Plus className="mr-2 h-4 w-4" />

--- a/src/components/users-table.tsx
+++ b/src/components/users-table.tsx
@@ -16,6 +16,7 @@ import { UserPasswordDialog } from './user-password-dialog';
 import { useSession } from '@/lib/session';
 import { PaginationBar } from './pagination/PaginationBar';
 import type { PageEnvelope } from '@/lib/pagination';
+import { Switch } from '@/components/ui/switch';
 
 interface UsersTableProps {
   data?: PageEnvelope<User>;
@@ -23,6 +24,8 @@ interface UsersTableProps {
   onLimitChange: (limit: number) => void;
   searchTerm: string;
   onSearchChange: (value: string) => void;
+  includeInactive: boolean;
+  onToggleInactive: (checked: boolean) => void;
   onSaveUser: (payload: { data: User; file?: File | null }) => Promise<void> | void;
   onDeleteUser: (userId: string) => void;
   loading?: boolean;
@@ -43,6 +46,8 @@ export function UsersTable({
   onLimitChange,
   searchTerm,
   onSearchChange,
+  includeInactive,
+  onToggleInactive,
   onSaveUser,
   onDeleteUser,
   loading = false,
@@ -119,6 +124,10 @@ export function UsersTable({
                   value={searchTerm}
                   onChange={(e) => onSearchChange(e.target.value)}
                 />
+              </div>
+              <div className="flex items-center space-x-2">
+                <Switch id="show-inactive" checked={includeInactive} onCheckedChange={onToggleInactive} />
+                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Mostrar inactivos</label>
               </div>
               <Input type="file" ref={fileInputRef} className="hidden" onChange={handleFileChange}
                 accept=".csv, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel"

--- a/src/hooks/usePaginationState.ts
+++ b/src/hooks/usePaginationState.ts
@@ -37,6 +37,7 @@ export interface PaginationStateOptions {
   defaultLimit?: number;
   defaultSort?: SortOrder;
   defaultSearch?: string;
+  defaultIncludeInactive?: boolean;
 }
 
 export const usePaginationState = (options: PaginationStateOptions = {}) => {
@@ -48,6 +49,19 @@ export const usePaginationState = (options: PaginationStateOptions = {}) => {
   const defaultLimit = options.defaultLimit ?? DEFAULT_LIMIT;
   const defaultSort = options.defaultSort ?? "desc";
   const defaultSearch = options.defaultSearch ?? "";
+  const defaultIncludeInactive = options.defaultIncludeInactive ?? false;
+
+  const parseIncludeInactive = useCallback(
+    (raw: string | null | undefined): boolean => {
+      if (typeof raw === "string") {
+        const normalized = raw.trim().toLowerCase();
+        if (normalized === "true" || normalized === "1") return true;
+        if (normalized === "false" || normalized === "0") return false;
+      }
+      return defaultIncludeInactive;
+    },
+    [defaultIncludeInactive],
+  );
 
   const page = useMemo(
     () => parsePositiveInteger(searchParams?.get("page"), defaultPage),
@@ -72,23 +86,46 @@ export const usePaginationState = (options: PaginationStateOptions = {}) => {
     [defaultSearch, searchParams],
   );
 
+  const includeInactive = useMemo(() => {
+    const preferred = searchParams?.get("includeInactive");
+    if (preferred != null) return parseIncludeInactive(preferred);
+    const legacy = searchParams?.get("all");
+    if (legacy != null) return parseIncludeInactive(legacy);
+    return defaultIncludeInactive;
+  }, [defaultIncludeInactive, parseIncludeInactive, searchParams]);
+
   const commit = useCallback(
-    (next: { page?: number; limit?: number; sort?: SortOrder; search?: string }) => {
+    (next: {
+      page?: number;
+      limit?: number;
+      sort?: SortOrder;
+      search?: string;
+      includeInactive?: boolean;
+    }) => {
       const nextPage = parsePositiveInteger(next.page ?? page, defaultPage);
       const nextLimit = parsePositiveInteger(next.limit ?? limit, defaultLimit);
       const nextSort = sanitizeSort(next.sort ?? sort, defaultSort);
       const nextSearch = typeof next.search === "string" ? next.search : search;
+      const nextIncludeInactive =
+        typeof next.includeInactive === "boolean" ? next.includeInactive : includeInactive;
 
       pageDebug("src/hooks/usePaginationState.ts:commit", {
-        from: { page, limit, sort, search },
-        to: { page: nextPage, limit: nextLimit, sort: nextSort, search: nextSearch },
+        from: { page, limit, sort, search, includeInactive },
+        to: {
+          page: nextPage,
+          limit: nextLimit,
+          sort: nextSort,
+          search: nextSearch,
+          includeInactive: nextIncludeInactive,
+        },
       });
 
       if (
         nextPage === page &&
         nextLimit === limit &&
         nextSort === sort &&
-        nextSearch === search
+        nextSearch === search &&
+        nextIncludeInactive === includeInactive
       )
         return;
 
@@ -96,6 +133,8 @@ export const usePaginationState = (options: PaginationStateOptions = {}) => {
       params.set("page", String(nextPage));
       params.set("limit", String(nextLimit));
       params.set("sort", nextSort);
+      params.set("includeInactive", String(nextIncludeInactive));
+      params.set("all", nextIncludeInactive ? "1" : "0");
 
       if (typeof nextSearch === "string" && nextSearch.length > 0) {
         params.set("search", nextSearch);
@@ -110,6 +149,7 @@ export const usePaginationState = (options: PaginationStateOptions = {}) => {
       defaultPage,
       defaultSearch,
       defaultSort,
+      includeInactive,
       limit,
       page,
       router,
@@ -165,14 +205,22 @@ export const usePaginationState = (options: PaginationStateOptions = {}) => {
     [commit],
   );
 
+  const setIncludeInactive = useCallback(
+    (value: boolean) => {
+      commit({ includeInactive: Boolean(value) });
+    },
+    [commit],
+  );
+
   const params = useMemo(
     () => ({
       page,
       limit,
       sort,
       search,
+      includeInactive,
     }),
-    [limit, page, search, sort],
+    [includeInactive, limit, page, search, sort],
   );
 
   const queryString = useMemo(() => {
@@ -180,21 +228,25 @@ export const usePaginationState = (options: PaginationStateOptions = {}) => {
     url.set("page", String(page));
     url.set("limit", String(limit));
     url.set("sort", sort);
+    url.set("includeInactive", String(includeInactive));
+    url.set("all", includeInactive ? "1" : "0");
     if (typeof search === "string" && search.length > 0) {
       url.set("search", search);
     }
     return url.toString();
-  }, [limit, page, search, sort]);
+  }, [includeInactive, limit, page, search, sort]);
 
   return {
     page,
     limit,
     sort,
     search,
+    includeInactive,
     setPage,
     setLimit,
     setSort,
     setSearch,
+    setIncludeInactive,
     toggleSort,
     params,
     queryString,

--- a/src/services/http-helpers.ts
+++ b/src/services/http-helpers.ts
@@ -2,6 +2,29 @@ import { AxiosError } from "axios";
 
 export type AppError = { status?: number; message: string; data?: any };
 
+export type ListParams = {
+  page?: number;
+  limit?: number;
+  sort?: "asc" | "desc";
+  search?: string;
+  includeInactive?: boolean;
+};
+
+export function buildListQuery(p: ListParams) {
+  const params = new URLSearchParams();
+  if (p.page) params.set("page", String(p.page));
+  if (p.limit) params.set("limit", String(p.limit));
+  if (p.sort) params.set("sort", p.sort);
+  if (p.search?.trim()) params.set("search", p.search.trim());
+
+  if (typeof p.includeInactive === "boolean") {
+    params.set("includeInactive", String(p.includeInactive));
+    params.set("all", p.includeInactive ? "1" : "0");
+  }
+
+  return params.toString();
+}
+
 export function parseAxiosError(err: unknown): AppError {
   const e = err as AxiosError<any>;
   return {

--- a/src/services/pagesService.ts
+++ b/src/services/pagesService.ts
@@ -1,6 +1,7 @@
 import { api } from '@/lib/api';
 import { normalizeOne } from '@/lib/apiEnvelope';
 import { PageEnvelope } from '@/lib/pagination';
+import { buildListQuery, type ListParams } from '@/services/http-helpers';
 
 export interface PaginaUI {
   id: number;
@@ -10,14 +11,7 @@ export interface PaginaUI {
   createdAt?: string;
   activo?: boolean;
 }
-export interface GetPagesParams {
-  page?: number;
-  limit?: number;
-  sort?: 'asc' | 'desc';
-  search?: string;
-  showInactive?: boolean;
-  [key: string]: unknown;
-}
+export type GetPagesParams = ListParams;
 
 const toPagina = (page: any): PaginaUI => ({
   id: Number(page?.id ?? 0),
@@ -29,28 +23,9 @@ const toPagina = (page: any): PaginaUI => ({
 });
 
 export async function getPaginas(params: GetPagesParams = {}): Promise<PageEnvelope<PaginaUI>> {
-  const {
-    page = 1,
-    limit = 10,
-    sort = 'desc',
-    search,
-    showInactive = false,
-    ...rest
-  } = params;
-
-  const query: Record<string, unknown> = {
-    page,
-    limit,
-    sort,
-    showInactive,
-    ...rest,
-  };
-
-  if (typeof search === 'string' && search.trim() !== '') {
-    query.search = search.trim();
-  }
-
-  const { data } = await api.get<PageEnvelope<any>>('/paginas', { params: query });
+  const query = buildListQuery(params);
+  const url = query.length > 0 ? `/paginas?${query}` : '/paginas';
+  const { data } = await api.get<PageEnvelope<any>>(url);
   const envelope = data as PageEnvelope<any>;
   const items = Array.isArray(envelope.items) ? envelope.items.map(toPagina) : [];
 

--- a/src/services/rolesService.ts
+++ b/src/services/rolesService.ts
@@ -1,6 +1,7 @@
 import { api } from '@/lib/api';
 import { normalizeOne } from '@/lib/apiEnvelope';
 import { PageEnvelope } from '@/lib/pagination';
+import { buildListQuery, type ListParams } from '@/services/http-helpers';
 
 export interface Role {
   id?: string | number;
@@ -10,14 +11,7 @@ export interface Role {
   createdAt?: string;
 }
 
-export interface GetRolesParams {
-  page?: number;
-  limit?: number;
-  sort?: 'asc' | 'desc';
-  search?: string;
-  showInactive?: boolean;
-  [key: string]: unknown;
-}
+export type GetRolesParams = ListParams;
 
 const toRole = (role: any): Role => ({
   id: role?.id,
@@ -28,28 +22,9 @@ const toRole = (role: any): Role => ({
 });
 
 export async function getRoles(params: GetRolesParams = {}): Promise<PageEnvelope<Role>> {
-  const {
-    page = 1,
-    limit = 10,
-    sort = 'desc',
-    search,
-    showInactive = false,
-    ...rest
-  } = params;
-
-  const query: Record<string, unknown> = {
-    page,
-    limit,
-    sort,
-    showInactive,
-    ...rest,
-  };
-
-  if (typeof search === 'string' && search.trim() !== '') {
-    query.search = search.trim();
-  }
-
-  const { data } = await api.get<PageEnvelope<any>>('/roles', { params: query });
+  const query = buildListQuery(params);
+  const url = query.length > 0 ? `/roles?${query}` : '/roles';
+  const { data } = await api.get<PageEnvelope<any>>(url);
   const envelope = data as PageEnvelope<any>;
   const items = Array.isArray(envelope.items) ? envelope.items.map(toRole) : [];
 


### PR DESCRIPTION
## Summary
- add shared list query builder that outputs includeInactive/all flags for legacy support
- update users/roles/pages services and pagination hook to sync includeInactive state via the URL
- wire admin usuarios/roles/paginas UIs to the unified pagination state and expose a “Mostrar inactivos” toggle

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d4c033b0848332bca3aa26e941929f