### PR TITLE
Add safe area utilities and adjust header stacking

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --app-header-h: 56px;
+  --tabbar-h: 48px;
+}
+
+@supports (height: 100dvh) {
+  .h-screen-dvh {
+    min-height: 100dvh;
+  }
+}
+
+.safe-px {
+  padding-left: max(1rem, env(safe-area-inset-left));
+  padding-right: max(1rem, env(safe-area-inset-right));
+}
+
+.safe-pt {
+  padding-top: calc(var(--app-header-h) + env(safe-area-inset-top));
+}
+
 body {
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/components/general-header.tsx
+++ b/src/components/general-header.tsx
@@ -39,7 +39,7 @@ export function GeneralHeader() {
   }
 
   return (
-    <header className="sticky top-0 z-30 flex h-16 items-center gap-4 border-b bg-background/80 px-4 backdrop-blur-md sm:px-6">
+    <header className="sticky top-0 z-[80] flex h-16 items-center gap-4 border-b bg-background/80 px-4 backdrop-blur-md sm:px-6">
       {isDocumentDetailPage ? (
         <Button variant="ghost" size="icon" onClick={() => router.back()}>
           <ArrowLeft className="h-5 w-5" />


### PR DESCRIPTION
## Summary
- add global tokens for header/tab bar heights plus utility classes for dvh and safe-area padding
- update the general header to use the new stacking context with z-[80]

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4f450e2d483328eaae2ea07139509