### PR TITLE
Make document detail tabs sticky and add mobile signers accordion

### DIFF
--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -39,6 +39,12 @@ import {
   DocumentSummaryDialog,
   type DocumentSummaryDialogHandle,
 } from '@/components/ai/DocumentSummaryDialog';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 
 export default function DocumentDetailPage() {
   const params = useParams<{ id: string }>();
@@ -266,7 +272,24 @@ export default function DocumentDetailPage() {
             />
           </div>
           <div className="col-span-12 space-y-4 md:col-span-4 xl:col-span-3">
-            <SignersPanel firmantes={signersPanel} progress={progress} />
+            <Accordion
+              type="single"
+              collapsible
+              className="rounded-xl border bg-background md:hidden"
+              defaultValue="signers"
+            >
+              <AccordionItem value="signers" className="border-none">
+                <AccordionTrigger className="px-4 text-left text-base font-medium">
+                  Firmantes
+                </AccordionTrigger>
+                <AccordionContent className="px-4">
+                  <SignersPanel firmantes={signersPanel} progress={progress} showHeader={false} />
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+            <div className="hidden md:block">
+              <SignersPanel firmantes={signersPanel} progress={progress} />
+            </div>
             <div className="flex items-center gap-2">
               <Button
                 onClick={handleDownloadButtonClick}

--- a/src/components/document-detail/signers-panel.tsx
+++ b/src/components/document-detail/signers-panel.tsx
@@ -10,16 +10,40 @@ const statusClass = (signed: boolean) =>
     ? 'bg-green-100 text-green-800 border-green-400'
     : 'bg-yellow-100 text-yellow-800 border-yellow-400';
 
-export function SignersPanel({ firmantes, progress }: { firmantes: Signer[]; progress: number }) {
+type SignersPanelProps = {
+  firmantes: Signer[];
+  progress: number;
+  className?: string;
+  showHeader?: boolean;
+};
+
+export function SignersPanel({
+  firmantes,
+  progress,
+  className,
+  showHeader = true,
+}: SignersPanelProps) {
+  const rootClass = cn(showHeader ? 'space-y-4' : 'space-y-3', className);
+
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <h3 className="text-lg font-medium">Firmantes</h3>
-          <span className="text-sm text-muted-foreground">{Math.round(progress)}%</span>
+    <div className={rootClass}>
+      {showHeader ? (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-medium">Firmantes</h3>
+            <span className="text-sm text-muted-foreground">{Math.round(progress)}%</span>
+          </div>
+          <Progress value={progress} />
         </div>
-        <Progress value={progress} />
-      </div>
+      ) : (
+        <div className="space-y-1 text-sm">
+          <div className="flex items-center justify-between font-medium">
+            <span>Progreso</span>
+            <span className="text-muted-foreground">{Math.round(progress)}%</span>
+          </div>
+          <Progress value={progress} className="h-2" />
+        </div>
+      )}
       <ul className="space-y-3">
         {firmantes.map((f) => (
           <li key={`${f.id}-${f.responsabilidad}`} className="flex items-center justify-between">

--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
@@ -24,6 +24,8 @@ export function DocumentTabs({
   onTabChange,
 }: DocumentTabsProps) {
   const [activeTab, setActiveTab] = useState<DocumentTabValue>("firmas");
+  const [tabbarHeight, setTabbarHeight] = useState(0);
+  const tabbarRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -50,9 +52,37 @@ export function DocumentTabs({
     setActiveTab(value as DocumentTabValue);
   };
 
+  useEffect(() => {
+    const element = tabbarRef.current;
+    if (!element) return;
+
+    const updateHeight = () => {
+      setTabbarHeight(element.offsetHeight);
+    };
+
+    updateHeight();
+
+    const resizeObserver = typeof ResizeObserver !== "undefined" ? new ResizeObserver(updateHeight) : null;
+    resizeObserver?.observe(element);
+    window.addEventListener("resize", updateHeight);
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", updateHeight);
+    };
+  }, []);
+
+  const style: CSSProperties = {
+    // Provide a fallback height so the PDF container always has a value
+    ["--tabbar-h" as const]: `${tabbarHeight}px`,
+  };
+
   return (
-    <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
-      <div className="sticky top-0 z-20 mb-3 bg-background/90 pb-1 pt-2 backdrop-blur">
+    <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full" style={style}>
+      <div
+        ref={tabbarRef}
+        className="sticky top-[var(--app-header-h)] z-20 mb-3 border-b border-border bg-background/80 pb-1 pt-2 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      >
         <TabsList className="grid h-auto w-full grid-cols-2 gap-2 rounded-lg bg-muted p-1 text-xs font-medium sm:text-sm">
           <TabsTrigger value="firmas" className="rounded-md px-2 py-2">
             Cuadro de firmas

--- a/src/components/document/PDFViewer.tsx
+++ b/src/components/document/PDFViewer.tsx
@@ -83,7 +83,7 @@ export function PDFViewer({
   }, [onRefresh]);
 
   const containerClass = cn(
-    "relative w-full h-[60vh] md:h-[78vh] rounded-xl border bg-background overflow-hidden",
+    "relative w-full rounded-xl border bg-background overflow-auto h-[calc(100dvh-var(--app-header-h)-var(--tabbar-h)-1rem)]",
     className,
   );
 


### PR DESCRIPTION
## Summary
- make the document detail tab bar sticky beneath the app header and expose its height for layout calculations
- update the PDF viewer container to fill the viewport height and scroll independently of the page
- render the signer panel as an accordion on mobile while keeping the desktop sidebar layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4fd02bb088332845b717f8c832c5d