### PR TITLE
feat: add responsive cards for admin tables

### DIFF
--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -72,10 +72,10 @@ export function DocumentTabs({
     };
   }, []);
 
-  const style: CSSProperties = {
+  const style = {
     // Provide a fallback height so the PDF container always has a value
-    ["--tabbar-h" as const]: `${tabbarHeight}px`,
-  };
+    "--tabbar-h": `${tabbarHeight}px`,
+  } as CSSProperties;
 
   return (
     <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full" style={style}>

--- a/src/components/pages-table.tsx
+++ b/src/components/pages-table.tsx
@@ -14,6 +14,11 @@ import type { Page } from '@/services/pageService';
 import { PaginationBar } from './pagination/PaginationBar';
 import { DateCell } from '@/components/DateCell';
 import type { PageEnvelope } from '@/lib/pagination';
+import { CardList } from '@/components/responsive/card-list';
+import { useBreakpoint } from '@/hooks/use-breakpoint';
+import { FiltersBar, FilterChips, type FilterChip } from './filters/filters-bar';
+import { FiltersDrawer } from './filters/filters-drawer';
+import { cn } from '@/lib/utils';
 
 interface PagesTableProps {
   data?: PageEnvelope<Page>;
@@ -44,6 +49,7 @@ export function PagesTable({
 }: PagesTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedPage, setSelectedPage] = useState<Page | undefined>(undefined);
+  const isMdUp = useBreakpoint('md');
 
   const rows = data?.items ?? [];
   const total = data?.total ?? 0;
@@ -68,111 +74,251 @@ export function PagesTable({
     closeModal();
   };
 
+  const renderFilters = (variant: 'bar' | 'drawer') => {
+    const isDrawer = variant === 'drawer';
+
+    return (
+      <>
+        <div
+          className={cn(
+            'relative flex-1 min-w-[200px] md:max-w-xs',
+            isDrawer && 'w-full',
+          )}
+        >
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Buscar páginas..."
+            className={cn('pl-8', isDrawer && 'w-full')}
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
+        </div>
+        <div
+          className={cn(
+            'flex items-center gap-2',
+            isDrawer && 'w-full flex-col items-stretch rounded-lg border p-3',
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Switch id="show-inactive-pages" checked={includeInactive} onCheckedChange={onToggleInactive} />
+            <label htmlFor="show-inactive-pages" className="text-sm">
+              Mostrar inactivos
+            </label>
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  const filterChips: FilterChip[] = [];
+  if (searchTerm.trim()) {
+    filterChips.push({
+      id: 'search',
+      label: `Búsqueda: "${searchTerm}"`,
+      onRemove: () => onSearchChange(''),
+    });
+  }
+  if (includeInactive) {
+    filterChips.push({
+      id: 'inactive',
+      label: 'Mostrar inactivos',
+      onRemove: () => onToggleInactive(false),
+    });
+  }
+
+  const toCardItem = (pageItem: Page) => {
+    const hasUrl = Boolean(pageItem.url);
+    const hasDescription = Boolean(pageItem.descripcion);
+    const secondaryContent = hasUrl || hasDescription ? (
+      <div className="flex flex-col gap-1 text-sm text-muted-foreground">
+        {hasUrl ? <span className="truncate">{pageItem.url}</span> : null}
+        {hasDescription ? <span className="line-clamp-2">{pageItem.descripcion}</span> : null}
+      </div>
+    ) : undefined;
+
+    return {
+      id: pageItem.id,
+      primary: <span className="truncate">{pageItem.nombre}</span>,
+      secondary: secondaryContent,
+      meta: (
+        <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+          <Badge variant={pageItem.activo ? 'default' : 'secondary'}>
+            {pageItem.activo ? 'Activa' : 'Inactiva'}
+          </Badge>
+          {pageItem.createdAt ? (
+            <div className="flex flex-col">
+              <span className="text-xs font-semibold uppercase tracking-wide text-foreground/80">Fecha</span>
+              <span className="text-sm text-foreground">
+                <DateCell value={pageItem.createdAt} />
+              </span>
+            </div>
+          ) : null}
+        </div>
+      ),
+      actions: (
+        <div className="flex flex-col items-end gap-2">
+          <Button type="button" size="sm" onClick={() => openModal(pageItem)}>
+            Editar
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Abrir menú">
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="end"
+              collisionPadding={16}
+              className="min-w-[12rem] max-w-[calc(100vw-2rem)]"
+            >
+              <DropdownMenuItem onClick={() => openModal(pageItem)}>
+                <Edit className="mr-2 h-4 w-4" />
+                <span>Editar</span>
+              </DropdownMenuItem>
+              {pageItem.activo ? (
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={() => onDeletePage(pageItem.id!)}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  <span>Eliminar</span>
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={() => onRestorePage(pageItem.id!)}>
+                  <RotateCcw className="mr-2 h-4 w-4" />
+                  <span>Restaurar</span>
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      ),
+    };
+  };
+
   return (
     <>
       <Card className="w-full h-full flex flex-col glassmorphism">
         <CardHeader>
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div className="space-y-1.5">
-              <CardTitle>Gestión de Páginas ({total})</CardTitle>
-              <CardDescription>Administre las páginas de la plataforma.</CardDescription>
-            </div>
-            <div className="flex items-center gap-2 flex-wrap justify-end">
-              <div className="relative w-full md:w-auto flex-grow">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Buscar páginas..."
-                  className="pl-8"
-                  value={searchTerm}
-                  onChange={(e) => onSearchChange(e.target.value)}
-                />
+          <div className="space-y-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div className="space-y-1.5">
+                <CardTitle>Gestión de Páginas ({total})</CardTitle>
+                <CardDescription>Administre las páginas de la plataforma.</CardDescription>
               </div>
-              <div className="flex items-center space-x-2">
-                <Switch id="show-inactive" checked={includeInactive} onCheckedChange={onToggleInactive} />
-                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Mostrar inactivos</label>
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-end">
+                <FiltersDrawer renderFilters={renderFilters} chips={filterChips} title="Filtros de páginas" />
+                <Button onClick={() => openModal()}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Crear Página
+                </Button>
               </div>
-              <Button onClick={() => openModal()}>
-                <Plus className="mr-2 h-4 w-4" />
-                Crear Página
-              </Button>
             </div>
+            <FiltersBar renderFilters={renderFilters} chips={filterChips} />
+            <FilterChips chips={filterChips} className="md:hidden" />
           </div>
         </CardHeader>
         <CardContent className="flex-grow overflow-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Nombre</TableHead>
-                <TableHead className="hidden md:table-cell">URL</TableHead>
-                <TableHead className="hidden md:table-cell">Descripción</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead className="hidden md:table-cell">Fecha</TableHead>
-                <TableHead>Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-            {rows.map(pageItem => (
-              <TableRow key={pageItem.id}>
-                  <TableCell className="font-medium">{pageItem.nombre}</TableCell>
-                  <TableCell className="hidden md:table-cell">{pageItem.url}</TableCell>
-                  <TableCell className="hidden md:table-cell">{pageItem.descripcion}</TableCell>
-                  <TableCell>
-                    <Badge variant={pageItem.activo ? 'default' : 'secondary'}>
-                      {pageItem.activo ? 'Activa' : 'Inactiva'}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    <DateCell value={pageItem.createdAt} />
-                  </TableCell>
-                  <TableCell>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="h-8 w-8 p-0">
-                          <span className="sr-only">Abrir menú</span>
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => openModal(pageItem)}>
-                          <Edit className="mr-2 h-4 w-4" />
-                          <span>Editar</span>
-                        </DropdownMenuItem>
-                        {pageItem.activo ? (
-                          <DropdownMenuItem className="text-destructive focus:text-destructive" onClick={() => onDeletePage(pageItem.id!)}>
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            <span>Eliminar</span>
-                          </DropdownMenuItem>
-                        ) : (
-                          <DropdownMenuItem onClick={() => onRestorePage(pageItem.id!)}>
-                            <RotateCcw className="mr-2 h-4 w-4" />
-                            <span>Restaurar</span>
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </TableCell>
+          {isMdUp ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nombre</TableHead>
+                  <TableHead className="hidden md:table-cell">URL</TableHead>
+                  <TableHead className="hidden md:table-cell">Descripción</TableHead>
+                  <TableHead>Estado</TableHead>
+                  <TableHead className="hidden md:table-cell">Fecha</TableHead>
+                  <TableHead>Acciones</TableHead>
                 </TableRow>
-            ))}
-            {!loading && rows.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={6} className="text-center py-4 text-sm text-muted-foreground">
-                  No hay páginas.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </CardContent>
-      <PaginationBar
-        total={total}
-        page={currentPage}
-        pages={totalPages}
-        limit={currentLimit}
-        hasPrev={hasPrev}
-        hasNext={hasNext}
-        onPageChange={onPageChange}
-        onLimitChange={onLimitChange}
-      />
+              </TableHeader>
+              <TableBody>
+                {rows.map((pageItem) => (
+                  <TableRow key={pageItem.id}>
+                    <TableCell className="font-medium">{pageItem.nombre}</TableCell>
+                    <TableCell className="hidden md:table-cell">{pageItem.url}</TableCell>
+                    <TableCell className="hidden md:table-cell">{pageItem.descripcion}</TableCell>
+                    <TableCell>
+                      <Badge variant={pageItem.activo ? 'default' : 'secondary'}>
+                        {pageItem.activo ? 'Activa' : 'Inactiva'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell">
+                      <DateCell value={pageItem.createdAt} />
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" className="h-8 w-8 p-0">
+                            <span className="sr-only">Abrir menú</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          collisionPadding={16}
+                          className="min-w-[12rem] max-w-[calc(100vw-2rem)]"
+                        >
+                          <DropdownMenuItem onClick={() => openModal(pageItem)}>
+                            <Edit className="mr-2 h-4 w-4" />
+                            <span>Editar</span>
+                          </DropdownMenuItem>
+                          {pageItem.activo ? (
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive"
+                              onClick={() => onDeletePage(pageItem.id!)}
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              <span>Eliminar</span>
+                            </DropdownMenuItem>
+                          ) : (
+                            <DropdownMenuItem onClick={() => onRestorePage(pageItem.id!)}>
+                              <RotateCcw className="mr-2 h-4 w-4" />
+                              <span>Restaurar</span>
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!loading && rows.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={6} className="text-center py-4 text-sm text-muted-foreground">
+                      No hay páginas.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {rows.length > 0 ? (
+                <CardList
+                  items={rows.map(toCardItem)}
+                  primary={(item) => item.primary}
+                  secondary={(item) => item.secondary}
+                  meta={(item) => item.meta}
+                  actions={(item) => item.actions}
+                  gridClassName="grid grid-cols-1 sm:grid-cols-2 gap-3"
+                />
+              ) : (
+                !loading && (
+                  <p className="py-6 text-center text-sm text-muted-foreground">No hay páginas.</p>
+                )
+              )}
+            </div>
+          )}
+        </CardContent>
+        <PaginationBar
+          total={total}
+          page={currentPage}
+          pages={totalPages}
+          limit={currentLimit}
+          hasPrev={hasPrev}
+          hasNext={hasNext}
+          onPageChange={onPageChange}
+          onLimitChange={onLimitChange}
+        />
       </Card>
       <PageFormModal
         isOpen={isModalOpen}

--- a/src/components/responsive/card-list.tsx
+++ b/src/components/responsive/card-list.tsx
@@ -10,6 +10,7 @@ export interface CardListProps<T> {
   meta?: (item: T) => React.ReactNode;
   actions?: (item: T) => React.ReactNode;
   className?: string;
+  gridClassName?: string;
 }
 
 export function CardList<T>({
@@ -19,13 +20,18 @@ export function CardList<T>({
   meta,
   actions,
   className,
+  gridClassName,
 }: CardListProps<T>) {
   if (!items.length) {
     return null;
   }
 
+  const containerClassName = gridClassName
+    ? cn(gridClassName, className)
+    : cn("space-y-3", className);
+
   return (
-    <div className={cn("space-y-3", className)}>
+    <div className={containerClassName}>
       {items.map((item, index) => {
         const key =
           typeof item === "object" && item !== null && "id" in item

--- a/src/components/roles-table.tsx
+++ b/src/components/roles-table.tsx
@@ -14,6 +14,11 @@ import type { Role } from '@/services/roleService';
 import { PaginationBar } from './pagination/PaginationBar';
 import { DateCell } from '@/components/DateCell';
 import type { PageEnvelope } from '@/lib/pagination';
+import { CardList } from '@/components/responsive/card-list';
+import { useBreakpoint } from '@/hooks/use-breakpoint';
+import { FiltersBar, FilterChips, type FilterChip } from './filters/filters-bar';
+import { FiltersDrawer } from './filters/filters-drawer';
+import { cn } from '@/lib/utils';
 
 interface RolesTableProps {
   data?: PageEnvelope<Role>;
@@ -44,6 +49,7 @@ export function RolesTable({
 }: RolesTableProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
+  const isMdUp = useBreakpoint('md');
 
   const roles = data?.items ?? [];
   const total = data?.total ?? 0;
@@ -68,112 +74,240 @@ export function RolesTable({
     closeModal();
   };
 
+  const renderFilters = (variant: 'bar' | 'drawer') => {
+    const isDrawer = variant === 'drawer';
+
+    return (
+      <>
+        <div
+          className={cn(
+            'relative flex-1 min-w-[200px] md:max-w-xs',
+            isDrawer && 'w-full',
+          )}
+        >
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Buscar roles..."
+            className={cn('pl-8', isDrawer && 'w-full')}
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+          />
+        </div>
+        <div
+          className={cn(
+            'flex items-center gap-2',
+            isDrawer && 'w-full flex-col items-stretch rounded-lg border p-3',
+          )}
+        >
+          <div className="flex items-center gap-2">
+            <Switch id="show-inactive" checked={includeInactive} onCheckedChange={onToggleInactive} />
+            <label htmlFor="show-inactive" className="text-sm">
+              Mostrar inactivos
+            </label>
+          </div>
+        </div>
+      </>
+    );
+  };
+
+  const filterChips: FilterChip[] = [];
+  if (searchTerm.trim()) {
+    filterChips.push({
+      id: 'search',
+      label: `Búsqueda: "${searchTerm}"`,
+      onRemove: () => onSearchChange(''),
+    });
+  }
+  if (includeInactive) {
+    filterChips.push({
+      id: 'inactive',
+      label: 'Mostrar inactivos',
+      onRemove: () => onToggleInactive(false),
+    });
+  }
+
+  const toCardItem = (role: Role) => ({
+    id: role.id,
+    primary: <span className="truncate">{role.nombre}</span>,
+    secondary: role.descripcion ? (
+      <span className="line-clamp-2 text-muted-foreground">{role.descripcion}</span>
+    ) : undefined,
+    meta: (
+      <div className="flex flex-col gap-2 text-sm text-muted-foreground">
+        <Badge variant={role.activo ? 'default' : 'secondary'}>
+          {role.activo ? 'Activa' : 'Inactiva'}
+        </Badge>
+        {role.createdAt ? (
+          <div className="flex flex-col">
+            <span className="text-xs font-semibold uppercase tracking-wide text-foreground/80">Fecha</span>
+            <span className="text-sm text-foreground">
+              <DateCell value={role.createdAt} />
+            </span>
+          </div>
+        ) : null}
+      </div>
+    ),
+    actions: (
+      <div className="flex flex-col items-end gap-2">
+        <Button type="button" size="sm" onClick={() => openModal(role)}>
+          Editar
+        </Button>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" className="h-8 w-8 p-0" aria-label="Abrir menú">
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            align="end"
+            collisionPadding={16}
+            className="min-w-[12rem] max-w-[calc(100vw-2rem)]"
+          >
+            <DropdownMenuItem onClick={() => openModal(role)}>
+              <Edit className="mr-2 h-4 w-4" />
+              <span>Editar</span>
+            </DropdownMenuItem>
+            {role.activo ? (
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => onDeleteRole(String(role.id ?? ''))}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                <span>Eliminar</span>
+              </DropdownMenuItem>
+            ) : (
+              <DropdownMenuItem onClick={() => onRestoreRole(String(role.id ?? ''))}>
+                <RotateCcw className="mr-2 h-4 w-4" />
+                <span>Restaurar</span>
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    ),
+  });
+
   return (
     <>
       <Card className="w-full h-full flex flex-col glassmorphism">
         <CardHeader>
-          <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
-            <div className="space-y-1.5">
-              <CardTitle>Gestión de Roles ({total})</CardTitle>
-              <CardDescription>Administre los roles de la plataforma.</CardDescription>
-            </div>
-            <div className="flex items-center gap-2 flex-wrap justify-end">
-              <div className="relative w-full md:w-auto flex-grow">
-                <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-                <Input
-                  placeholder="Buscar roles..."
-                  className="pl-8"
-                  value={searchTerm}
-                  onChange={(e) => onSearchChange(e.target.value)}
-                />
+          <div className="space-y-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div className="space-y-1.5">
+                <CardTitle>Gestión de Roles ({total})</CardTitle>
+                <CardDescription>Administre los roles de la plataforma.</CardDescription>
               </div>
-              <div className="flex items-center space-x-2">
-                <Switch id="show-inactive" checked={includeInactive} onCheckedChange={onToggleInactive} />
-                <label htmlFor="show-inactive" className="text-sm whitespace-nowrap">Mostrar inactivos</label>
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-end">
+                <FiltersDrawer renderFilters={renderFilters} chips={filterChips} title="Filtros de roles" />
+                <Button onClick={() => openModal()}>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Crear Rol
+                </Button>
               </div>
-              <Button onClick={() => openModal()}>
-                <Plus className="mr-2 h-4 w-4" />
-                Crear Rol
-              </Button>
             </div>
+            <FiltersBar renderFilters={renderFilters} chips={filterChips} />
+            <FilterChips chips={filterChips} className="md:hidden" />
           </div>
         </CardHeader>
         <CardContent className="flex-grow overflow-auto">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Nombre</TableHead>
-                <TableHead className="hidden md:table-cell">Descripción</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead className="hidden md:table-cell">Fecha</TableHead>
-                <TableHead>Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {roles.map(role => (
-                <TableRow key={role.id}>
-                  <TableCell className="font-medium">{role.nombre}</TableCell>
-                  <TableCell className="hidden md:table-cell">{role.descripcion}</TableCell>
-                  <TableCell>
-                    <Badge variant={role.activo ? 'default' : 'secondary'}>
-                      {role.activo ? 'Activa' : 'Inactiva'}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="hidden md:table-cell">
-                    <DateCell value={role.createdAt} />
-                  </TableCell>
-                  <TableCell>
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" className="h-8 w-8 p-0">
-                          <span className="sr-only">Abrir menú</span>
-                          <MoreHorizontal className="h-4 w-4" />
-                        </Button>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent align="end">
-                        <DropdownMenuItem onClick={() => openModal(role)}>
-                          <Edit className="mr-2 h-4 w-4" />
-                          <span>Editar</span>
-                        </DropdownMenuItem>
-                        {role.activo ? (
-                          <DropdownMenuItem
-                            className="text-destructive focus:text-destructive"
-                            onClick={() => onDeleteRole(String(role.id ?? ''))}
-                          >
-                            <Trash2 className="mr-2 h-4 w-4" />
-                            <span>Eliminar</span>
-                          </DropdownMenuItem>
-                        ) : (
-                          <DropdownMenuItem onClick={() => onRestoreRole(String(role.id ?? ''))}>
-                            <RotateCcw className="mr-2 h-4 w-4" />
-                            <span>Restaurar</span>
-                          </DropdownMenuItem>
-                        )}
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  </TableCell>
+          {isMdUp ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nombre</TableHead>
+                  <TableHead className="hidden md:table-cell">Descripción</TableHead>
+                  <TableHead>Estado</TableHead>
+                  <TableHead className="hidden md:table-cell">Fecha</TableHead>
+                  <TableHead>Acciones</TableHead>
                 </TableRow>
-            ))}
-            {!loading && roles.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={5} className="text-center py-4 text-sm text-muted-foreground">
-                  No hay roles.
-                </TableCell>
-              </TableRow>
-            )}
-          </TableBody>
-        </Table>
-      </CardContent>
-      <PaginationBar
-        total={total}
-        page={currentPage}
-        pages={totalPages}
-        limit={currentLimit}
-        hasPrev={hasPrev}
-        hasNext={hasNext}
-        onPageChange={onPageChange}
-        onLimitChange={onLimitChange}
-      />
+              </TableHeader>
+              <TableBody>
+                {roles.map((role) => (
+                  <TableRow key={role.id}>
+                    <TableCell className="font-medium">{role.nombre}</TableCell>
+                    <TableCell className="hidden md:table-cell">{role.descripcion}</TableCell>
+                    <TableCell>
+                      <Badge variant={role.activo ? 'default' : 'secondary'}>
+                        {role.activo ? 'Activa' : 'Inactiva'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="hidden md:table-cell">
+                      <DateCell value={role.createdAt} />
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" className="h-8 w-8 p-0">
+                            <span className="sr-only">Abrir menú</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          collisionPadding={16}
+                          className="min-w-[12rem] max-w-[calc(100vw-2rem)]"
+                        >
+                          <DropdownMenuItem onClick={() => openModal(role)}>
+                            <Edit className="mr-2 h-4 w-4" />
+                            <span>Editar</span>
+                          </DropdownMenuItem>
+                          {role.activo ? (
+                            <DropdownMenuItem
+                              className="text-destructive focus:text-destructive"
+                              onClick={() => onDeleteRole(String(role.id ?? ''))}
+                            >
+                              <Trash2 className="mr-2 h-4 w-4" />
+                              <span>Eliminar</span>
+                            </DropdownMenuItem>
+                          ) : (
+                            <DropdownMenuItem onClick={() => onRestoreRole(String(role.id ?? ''))}>
+                              <RotateCcw className="mr-2 h-4 w-4" />
+                              <span>Restaurar</span>
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {!loading && roles.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center py-4 text-sm text-muted-foreground">
+                      No hay roles.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {roles.length > 0 ? (
+                <CardList
+                  items={roles.map(toCardItem)}
+                  primary={(item) => item.primary}
+                  secondary={(item) => item.secondary}
+                  meta={(item) => item.meta}
+                  actions={(item) => item.actions}
+                  gridClassName="grid grid-cols-1 sm:grid-cols-2 gap-3"
+                />
+              ) : (
+                !loading && (
+                  <p className="py-6 text-center text-sm text-muted-foreground">No hay roles.</p>
+                )
+              )}
+            </div>
+          )}
+        </CardContent>
+        <PaginationBar
+          total={total}
+          page={currentPage}
+          pages={totalPages}
+          limit={currentLimit}
+          hasPrev={hasPrev}
+          hasNext={hasNext}
+          onPageChange={onPageChange}
+          onLimitChange={onLimitChange}
+        />
       </Card>
       <RoleFormModal
         isOpen={isModalOpen}

--- a/src/hooks/use-breakpoint.ts
+++ b/src/hooks/use-breakpoint.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+const queries: Record<string, string> = {
+  sm: "(min-width: 640px)",
+  md: "(min-width: 768px)",
+  lg: "(min-width: 1024px)",
+  xl: "(min-width: 1280px)",
+};
+
+export function useBreakpoint<Key extends keyof typeof queries>(key: Key) {
+  const query = queries[key];
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === "undefined" || !query) {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  });
+
+  useEffect(() => {
+    const mq = window.matchMedia(query);
+    const listener = () => setMatches(mq.matches);
+    listener();
+    mq.addEventListener("change", listener);
+    return () => mq.removeEventListener("change", listener);
+  }, [query]);
+
+  return matches;
+}


### PR DESCRIPTION
## Summary
- add a shared useBreakpoint hook and allow CardList to render grid layouts for responsive cards
- switch document, role, page, and supervision tables to cards on mobile with adapters and integrated filter drawer/bar patterns
- tidy DocumentTabs custom property typing to satisfy type-checking

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5006bf36c8332becfe859cf8c1dec