### PR TITLE
Fix dialog focus and nested portal containers

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -6,6 +6,11 @@ import { X } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 
+const DialogPortalContainerContext = React.createContext<HTMLElement | null>(null)
+
+export const useDialogPortalContainer = () =>
+  React.useContext(DialogPortalContainerContext)
+
 export const Dialog = DialogPrimitive.Root
 
 export const DialogTrigger = DialogPrimitive.Trigger
@@ -42,9 +47,19 @@ export const DialogContent = React.forwardRef<
   { className, children, maxWidthPx = 640, ...props },
   ref
 ) {
-  const handleOpenAutoFocus = React.useCallback((e: Event) => {
-    e.preventDefault()
-  }, [])
+  const contentRef = React.useRef<HTMLDivElement | null>(null)
+  const isIOS =
+    typeof navigator !== "undefined" &&
+    (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1))
+  const handleOpenAutoFocus = React.useCallback(
+    (e: Event) => {
+      if (isIOS) {
+        e.preventDefault()
+      }
+    },
+    [isIOS]
+  )
 
   return (
     <DialogPortal>
@@ -61,6 +76,8 @@ export const DialogContent = React.forwardRef<
         {...props}
       >
         <div
+          ref={contentRef}
+          data-dialog-content
           className={cn(
             "relative rounded-2xl bg-background",
             "w-[calc(100vw-32px)]",
@@ -69,7 +86,9 @@ export const DialogContent = React.forwardRef<
             "overflow-y-auto p-4"
           )}
         >
-          {children}
+          <DialogPortalContainerContext.Provider value={contentRef.current}>
+            {children}
+          </DialogPortalContainerContext.Provider>
 
           <DialogPrimitive.Close
             className={cn(

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -6,6 +6,7 @@ import { Check, ChevronRight, Circle } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useDialogPortalContainer } from "@/components/ui/dialog"
 
 const DropdownMenu = DropdownMenuPrimitive.Root
 
@@ -65,9 +66,10 @@ const DropdownMenuContent = React.forwardRef<
   const isMobile = useIsMobile()
   const resolvedSideOffset = sideOffset ?? (isMobile ? 4 : 8)
   const resolvedCollisionPadding = collisionPadding ?? 16
+  const container = useDialogPortalContainer()
 
   return (
-    <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Portal container={container ?? undefined}>
       <DropdownMenuPrimitive.Content
         ref={ref}
         sideOffset={resolvedSideOffset}

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -5,6 +5,7 @@ import * as PopoverPrimitive from "@radix-ui/react-popover"
 
 import { cn } from "@/lib/utils"
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useDialogPortalContainer } from "@/components/ui/dialog"
 
 const Popover = PopoverPrimitive.Root
 
@@ -17,9 +18,10 @@ const PopoverContent = React.forwardRef<
   const isMobile = useIsMobile()
   const resolvedSideOffset = sideOffset ?? (isMobile ? 4 : 8)
   const resolvedCollisionPadding = collisionPadding ?? 16
+  const container = useDialogPortalContainer()
 
   return (
-    <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Portal container={container ?? undefined}>
       <PopoverPrimitive.Content
         ref={ref}
         align={align}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"
+import { useDialogPortalContainer } from "@/components/ui/dialog"
 
 const TooltipProvider = TooltipPrimitive.Provider
 
@@ -16,21 +17,27 @@ const TooltipArrow = TooltipPrimitive.Arrow
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, collisionPadding = 8, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    collisionPadding={collisionPadding}
-    className={cn(
-      "z-[95] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md",
-      "max-w-[calc(100vw-2rem)]",
-      "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
-      "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
-      className
-    )}
-    {...props}
-  />
-))
+>(({ className, sideOffset = 4, collisionPadding = 8, ...props }, ref) => {
+  const container = useDialogPortalContainer()
+
+  return (
+    <TooltipPrimitive.Portal container={container ?? undefined}>
+      <TooltipPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+        className={cn(
+          "z-[95] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md",
+          "max-w-[calc(100vw-2rem)]",
+          "data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
+          "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  )
+})
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider, TooltipArrow }


### PR DESCRIPTION
## Summary
- stop preventing dialog auto focus on desktop while exposing the dialog content element through context
- add a shared portal container for dropdown, popover, and tooltip primitives so nested overlays stay inside dialogs

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5129371608332bfeebc4fae0ce74b