### PR TITLE
Adjust dialog overlay styling

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -27,9 +27,12 @@ export const DialogOverlay = React.forwardRef<
     <DialogPrimitive.Overlay
       ref={ref}
       className={cn(
-        "fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm",
+        "fixed inset-0 z-[100]",
+        "bg-background/40 backdrop-blur-sm",
+        "md:bg-black/60 md:backdrop-blur-0",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
-        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+        "transition-opacity",
         className
       )}
       {...props}
@@ -92,6 +95,7 @@ export const DialogContent = React.forwardRef<
           className={cn(
             "relative overflow-y-auto overflow-x-hidden",
             "rounded-2xl bg-background",
+            "shadow-2xl ring-1 ring-border/50",
             "box-border",
             "p-6",
             "mx-auto"


### PR DESCRIPTION
## Summary
- implement responsive overlay styling for dialogs, keeping blur only on mobile
- add visual separation to dialog content via shadow and subtle ring

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d51d761dcc83329efbf2972f15c137