### PR TITLE
Adjust overlay scrims for desktop

### DIFF
--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -18,7 +18,11 @@ const AlertDialogOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50",
+      "bg-background/40 backdrop-blur-sm",
+      "md:bg-black/70 md:backdrop-blur-0 md:[backdrop-filter:none]",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -26,10 +26,11 @@ export const DialogOverlay = React.forwardRef<
   return (
     <DialogPrimitive.Overlay
       ref={ref}
+      // Importante: en desktop no usamos backdrop-blur; cualquier difuminado extra proviene de reglas globales.
       className={cn(
         "fixed inset-0 z-[100]",
         "bg-background/40 backdrop-blur-sm",
-        "md:bg-black/60 md:backdrop-blur-0",
+        "md:bg-black/70 md:backdrop-blur-0 md:[backdrop-filter:none]",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
         "transition-opacity",

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -21,7 +21,11 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-50",
+      "bg-background/40 backdrop-blur-sm",
+      "md:bg-black/70 md:backdrop-blur-0 md:[backdrop-filter:none]",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- remove desktop blur from dialog, sheet, and alert dialog overlays while keeping mobile backdrop blur
- darken desktop overlay scrims and add safeguard comment for future regressions
- preserve existing dialog content sizing while ensuring modal surfaces retain subtle ring and shadow

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d51ffc231c8332b98b9cd1be03c715