### PR TITLE
Adjust overlay blur to desktop-only behavior

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,6 +113,17 @@ body {
 
 @layer components {
   .glassmorphism {
-    @apply bg-card/60 backdrop-blur-lg border border-white/20 shadow-lg;
+    @apply bg-card/60 border border-white/20 shadow-lg;
+    @apply backdrop-blur-lg md:backdrop-blur-0;
+    @apply md:bg-card/95;
+  }
+}
+
+@layer utilities {
+  @screen md {
+    .no-blur-desktop {
+      backdrop-filter: none !important;
+      -webkit-backdrop-filter: none !important;
+    }
   }
 }

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -20,7 +20,7 @@ const AlertDialogOverlay = React.forwardRef<
     className={cn(
       "fixed inset-0 z-50",
       "bg-background/40 backdrop-blur-sm",
-      "md:bg-black/70 md:backdrop-blur-0 md:[backdrop-filter:none]",
+      "md:bg-black/75 md:backdrop-blur-0 md:no-blur-desktop",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -26,14 +26,12 @@ export const DialogOverlay = React.forwardRef<
   return (
     <DialogPrimitive.Overlay
       ref={ref}
-      // Importante: en desktop no usamos backdrop-blur; cualquier difuminado extra proviene de reglas globales.
       className={cn(
         "fixed inset-0 z-[100]",
         "bg-background/40 backdrop-blur-sm",
-        "md:bg-black/70 md:backdrop-blur-0 md:[backdrop-filter:none]",
+        "md:bg-black/75 md:backdrop-blur-0 md:no-blur-desktop",
         "data-[state=open]:animate-in data-[state=closed]:animate-out",
         "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
-        "transition-opacity",
         className
       )}
       {...props}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -23,7 +23,7 @@ const SheetOverlay = React.forwardRef<
     className={cn(
       "fixed inset-0 z-50",
       "bg-background/40 backdrop-blur-sm",
-      "md:bg-black/70 md:backdrop-blur-0 md:[backdrop-filter:none]",
+      "md:bg-black/75 md:backdrop-blur-0 md:no-blur-desktop",
       "data-[state=open]:animate-in data-[state=closed]:animate-out",
       "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className


### PR DESCRIPTION
## Summary
- update the global glassmorphism utility to disable blur at md+ and add a desktop blur reset helper
- align dialog, sheet, and alert-dialog overlays to remove blur on desktop while keeping mobile blur

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d522b5ad808332a39d028a3e68caf0