### PR TITLE
feat: responsive signer selection UI

### DIFF
--- a/src/app/admin/asignaciones/page.tsx
+++ b/src/app/admin/asignaciones/page.tsx
@@ -15,7 +15,6 @@ import { createCuadroFirma } from "@/services/documentsService";
 import { buildResponsables } from "@/lib/responsables";
 import { useToast } from "@/hooks/use-toast";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import {
   Table,
   TableBody,
@@ -24,6 +23,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { SignersTable } from "@/components/signers-table";
+import { SignersSelected } from "@/components/signers-selected";
 
 
 type Signatory = Omit<User, 'id'> & { id: number; responsibility: 'REVISA' | 'APRUEBA' | 'ENTERADO' | null };
@@ -32,12 +33,6 @@ const toNumericId = (raw: unknown): number | null => {
   if (typeof raw === 'number' && Number.isFinite(raw)) return raw;
   if (typeof raw === 'string' && raw.trim() !== '' && !Number.isNaN(Number(raw))) return Number(raw);
   return null;
-};
-
-const getInitials = (name: string) => {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length >= 2) return `${parts[0][0]}${parts[1][0]}`.toUpperCase();
-  return parts[0] ? parts[0][0].toUpperCase() : "";
 };
 
 export default function AsignacionesPage() {
@@ -325,46 +320,20 @@ const handleSubmit = async (event: React.FormEvent) => {
                 </div>
               </div>
 
-              <div className="border rounded-md max-h-56 overflow-y-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead></TableHead>
-                      <TableHead>Nombre</TableHead>
-                      <TableHead>Puesto</TableHead>
-                      <TableHead>Gerencia</TableHead>
-                      <TableHead className="text-right"></TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filteredUsers.map((user) => (
-                      <TableRow key={user.id}>
-                        <TableCell>
-                          <Avatar className="h-8 w-8">
-                            <AvatarImage src={user.avatar} alt={user.name} data-ai-hint="person avatar" />
-                            <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
-                          </Avatar>
-                        </TableCell>
-                        <TableCell className="font-medium">{user.name}</TableCell>
-                        <TableCell className="text-muted-foreground">{user.position}</TableCell>
-                        <TableCell className="text-muted-foreground">{user.department}</TableCell>
-                        <TableCell className="text-right">
-                          <Button type="button" size="sm" onClick={() => addSignatory(user)}>
-                            Agregar
-                          </Button>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
+              <SignersTable users={filteredUsers} onAdd={addSignatory} />
 
               <Separator className="my-2" />
 
-              <h4 className="text-sm font-medium">Firmantes Seleccionados ({signatories.length}):</h4>
+              <SignersSelected
+                signers={signatories.map((signer) => ({ id: signer.id, name: signer.name }))}
+                onRemove={(id) => removeSignatory(Number(id))}
+              />
+
               {signatories.length === 0 ? (
                 <div className="flex-grow flex items-center justify-center">
-                  <p className="text-sm text-muted-foreground text-center py-4">No hay firmantes agregados.</p>
+                  <p className="text-sm text-muted-foreground text-center py-4">
+                    No hay firmantes agregados.
+                  </p>
                 </div>
               ) : (
                 <div className="flex-grow overflow-y-auto border rounded-md">

--- a/src/components/responsive/card-list.tsx
+++ b/src/components/responsive/card-list.tsx
@@ -1,17 +1,91 @@
 import * as React from "react";
 
 import { Card, CardContent } from "@/components/ui/card";
+import { Button, type ButtonProps } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-export interface CardListProps<T> {
+export interface CardListAction
+  extends Pick<ButtonProps, "variant" | "size"> {
+  label: string;
+  onClick: () => void;
+  ariaLabel?: string;
+}
+
+export interface CardListItem {
+  id?: React.Key;
+  primary: React.ReactNode;
+  secondary?: React.ReactNode;
+  meta?: React.ReactNode;
+  actions?: React.ReactNode | CardListAction | CardListAction[];
+}
+
+export interface CardListProps<T = CardListItem> {
   items: T[];
-  primary: (item: T) => React.ReactNode;
+  primary?: (item: T) => React.ReactNode;
   secondary?: (item: T) => React.ReactNode;
   meta?: (item: T) => React.ReactNode;
   actions?: (item: T) => React.ReactNode;
   className?: string;
   gridClassName?: string;
 }
+
+const isCardListItem = (value: unknown): value is CardListItem =>
+  typeof value === "object" &&
+  value !== null &&
+  ("primary" in value ||
+    "secondary" in value ||
+    "meta" in value ||
+    "actions" in value);
+
+const isCardListAction = (value: unknown): value is CardListAction =>
+  typeof value === "object" &&
+  value !== null &&
+  "label" in value &&
+  "onClick" in value;
+
+const renderActions = (actions: CardListItem["actions"]) => {
+  if (!actions) return null;
+
+  if (React.isValidElement(actions) || typeof actions !== "object") {
+    return actions;
+  }
+
+  if (Array.isArray(actions)) {
+    const validActions = actions.filter(isCardListAction);
+    if (!validActions.length) return null;
+
+    return (
+      <div className="flex flex-wrap justify-end gap-2">
+        {validActions.map((action, index) => (
+          <Button
+            key={`${action.label}-${index}`}
+            size={action.size ?? "sm"}
+            variant={action.variant}
+            aria-label={action.ariaLabel ?? action.label}
+            onClick={() => action.onClick()}
+          >
+            {action.label}
+          </Button>
+        ))}
+      </div>
+    );
+  }
+
+  if (isCardListAction(actions)) {
+    return (
+      <Button
+        size={actions.size ?? "sm"}
+        variant={actions.variant}
+        aria-label={actions.ariaLabel ?? actions.label}
+        onClick={() => actions.onClick()}
+      >
+        {actions.label}
+      </Button>
+    );
+  }
+
+  return actions as React.ReactNode;
+};
 
 export function CardList<T>({
   items,
@@ -37,6 +111,7 @@ export function CardList<T>({
           typeof item === "object" && item !== null && "id" in item
             ? (item as { id?: React.Key }).id ?? index
             : index;
+        const cardItem = isCardListItem(item) ? item : undefined;
 
         return (
           <Card key={key} className="shadow-sm">
@@ -44,17 +119,23 @@ export function CardList<T>({
               <div className="flex items-start justify-between gap-4">
                 <div className="space-y-2">
                   <div className="text-base font-semibold leading-none tracking-tight">
-                    {primary(item)}
+                    {primary ? primary(item) : cardItem?.primary}
                   </div>
-                  {secondary ? (
+                  {secondary || cardItem?.secondary ? (
                     <div className="text-sm text-muted-foreground">
-                      {secondary(item)}
+                      {secondary ? secondary(item) : cardItem?.secondary}
                     </div>
                   ) : null}
-                  {meta ? <div className="text-sm">{meta(item)}</div> : null}
+                  {meta || cardItem?.meta ? (
+                    <div className="text-sm">
+                      {meta ? meta(item) : cardItem?.meta}
+                    </div>
+                  ) : null}
                 </div>
-                {actions ? (
-                  <div className="flex-shrink-0">{actions(item)}</div>
+                {actions || cardItem?.actions ? (
+                  <div className="flex-shrink-0">
+                    {actions ? actions(item) : renderActions(cardItem?.actions)}
+                  </div>
                 ) : null}
               </div>
             </CardContent>

--- a/src/components/signers-selected.tsx
+++ b/src/components/signers-selected.tsx
@@ -1,0 +1,46 @@
+import { Button } from "@/components/ui/button";
+
+interface SelectedSigner {
+  id: string | number;
+  name: string;
+}
+
+interface SignersSelectedProps {
+  signers: SelectedSigner[];
+  onRemove: (id: SelectedSigner["id"]) => void;
+  className?: string;
+}
+
+export function SignersSelected({ signers, onRemove, className }: SignersSelectedProps) {
+  return (
+    <div className={className}>
+      <h4 className="text-sm font-medium">
+        Firmantes Seleccionados ({signers.length})
+      </h4>
+      {signers.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {signers.map((signer) => (
+            <div
+              key={signer.id}
+              className="flex items-center gap-2 rounded-full border border-input bg-muted/60 px-3 py-1 text-sm"
+            >
+              <span className="max-w-[180px] truncate font-medium" title={signer.name}>
+                {signer.name}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs"
+                onClick={() => onRemove(signer.id)}
+                aria-label={`Quitar a ${signer.name}`}
+              >
+                Quitar
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/signers-table.tsx
+++ b/src/components/signers-table.tsx
@@ -1,0 +1,139 @@
+import * as React from "react";
+
+import { CardList, type CardListItem } from "@/components/responsive/card-list";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import type { User } from "@/lib/data";
+
+interface SignersTableProps {
+  users: User[];
+  onAdd: (user: User) => void;
+  className?: string;
+}
+
+const getInitials = (name: string) => {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) return `${parts[0]?.[0] ?? ""}${parts[1]?.[0] ?? ""}`.toUpperCase();
+  return parts[0] ? parts[0][0].toUpperCase() : "";
+};
+
+const toCardItem = (user: User, onAdd: (u: User) => void): CardListItem => {
+  const secondaryItems = [user.position, user.department]
+    .map((value) => value?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  return {
+    id: user.id ?? user.correoInstitucional ?? user.employeeCode,
+    primary: (
+      <div className="flex items-center gap-3">
+        <Avatar className="h-10 w-10">
+          <AvatarImage
+            src={user.urlFoto || user.fotoPerfil || user.avatar || undefined}
+            alt={user.name}
+            data-ai-hint="person avatar"
+          />
+          <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+        </Avatar>
+        <span className="font-medium">{user.name}</span>
+      </div>
+    ),
+    secondary: secondaryItems.length ? (
+      <div className="flex flex-col gap-1">
+        {secondaryItems.map((value) => (
+          <span key={`${user.id}-${value}`} className="truncate">
+            {value}
+          </span>
+        ))}
+      </div>
+    ) : null,
+    meta: user.correoInstitucional ? (
+      <span className="break-all text-muted-foreground">{user.correoInstitucional}</span>
+    ) : null,
+    actions: [
+      {
+        label: "Agregar",
+        onClick: () => onAdd(user),
+        ariaLabel: `Agregar a ${user.name}`,
+      },
+    ],
+  };
+};
+
+export function SignersTable({ users, onAdd, className }: SignersTableProps) {
+  const cardItems = React.useMemo(() => users.map((user) => toCardItem(user, onAdd)), [users, onAdd]);
+
+  return (
+    <div className={cn("border rounded-md", className)}>
+      <div className="md:hidden max-h-56 overflow-y-auto p-3">
+        {cardItems.length ? (
+          <CardList items={cardItems} className="space-y-3" />
+        ) : (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No se encontraron firmantes.
+          </p>
+        )}
+      </div>
+
+      <div className="hidden md:block">
+        <div className="max-h-56 overflow-y-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-16" />
+                <TableHead>Nombre</TableHead>
+                <TableHead>Puesto</TableHead>
+                <TableHead>Gerencia</TableHead>
+                <TableHead className="text-right">Acciones</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {users.map((user) => (
+                <TableRow key={user.id ?? user.correoInstitucional}>
+                  <TableCell>
+                    <Avatar className="h-8 w-8">
+                      <AvatarImage
+                        src={user.urlFoto || user.fotoPerfil || user.avatar || undefined}
+                        alt={user.name}
+                        data-ai-hint="person avatar"
+                      />
+                      <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+                    </Avatar>
+                  </TableCell>
+                  <TableCell className="font-medium">{user.name}</TableCell>
+                  <TableCell className="text-muted-foreground">{user.position}</TableCell>
+                  <TableCell className="text-muted-foreground">{user.department}</TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      type="button"
+                      size="sm"
+                      onClick={() => onAdd(user)}
+                      aria-label={`Agregar a ${user.name}`}
+                    >
+                      Agregar
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+              {users.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="h-24 text-center text-sm text-muted-foreground">
+                    No se encontraron firmantes.
+                  </TableCell>
+                </TableRow>
+              ) : null}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend CardList to support declarative card items and action buttons
- add responsive SignersTable and SignersSelected components for signer management
- update the asignaciones admin page to use the new mobile cards and removable chips

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d527540034833286a46b0c302c3297