### PR TITLE
feat: integrate local pdf.js viewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ out/
 # production
 build/
 dist/
+!/public/pdfjs/build/
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "prepare:pdfjs": "shx rm -rf public/pdfjs/build && shx mkdir -p public/pdfjs/build && shx cp node_modules/pdfjs-dist/build/* public/pdfjs/build",
     "dev": "next dev --turbopack -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
@@ -51,6 +52,7 @@
     "lucide-react": "^0.475.0",
     "next": "15.3.3",
     "patch-package": "^8.0.0",
+    "pdfjs-dist": "^4.5.136",
     "react": "^18.3.1",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
@@ -77,6 +79,7 @@
     "eslint-config-next": "^15",
     "genkit-cli": "^1.14.1",
     "postcss": "^8",
+    "shx": "^0.3.4",
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
     "typescript-eslint": "^8"

--- a/public/pdfjs/build/README.txt
+++ b/public/pdfjs/build/README.txt
@@ -1,0 +1,2 @@
+PDF.js runtime assets are populated via `npm run prepare:pdfjs`.
+Run this script after installing dependencies to copy the official files from `pdfjs-dist`.

--- a/public/pdfjs/web/viewer.html
+++ b/public/pdfjs/web/viewer.html
@@ -1,505 +1,140 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="es">
   <head>
     <meta charset="utf-8" />
-    <title>Visor de PDF</title>
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover"
     />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.5.136/pdf_viewer.min.css"
-      crossorigin="anonymous"
-    />
+    <title>Visor PDF</title>
+    <link rel="stylesheet" href="../build/pdf_viewer.css" />
     <style>
-      :root {
-        color-scheme: light dark;
-      }
-
-      * {
-        box-sizing: border-box;
-      }
-
-      html,
-      body {
-        height: 100%;
-        margin: 0;
-        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background-color: #0f172a;
-        color: #0f172a;
-      }
-
-      body {
-        display: flex;
-        flex-direction: column;
-        background-color: #f8fafc;
-        color: #0f172a;
-      }
-
-      @media (prefers-color-scheme: dark) {
-        body {
-          background-color: #0f172a;
-          color: #e2e8f0;
-        }
-
-        #toolbar {
-          background: rgba(15, 23, 42, 0.85);
-          border-color: rgba(148, 163, 184, 0.2);
-        }
-
-        #toolbar button,
-        #toolbar input,
-        #toolbar select {
-          background-color: rgba(30, 41, 59, 0.7);
-          color: #e2e8f0;
-          border-color: rgba(148, 163, 184, 0.35);
-        }
-
-        #toolbar button:hover,
-        #toolbar button:focus-visible {
-          background-color: rgba(51, 65, 85, 0.85);
-        }
-
-        #viewerContainer {
-          background: #020617;
-        }
-      }
-
-      #toolbar {
-        position: sticky;
-        top: 0;
-        z-index: 10;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        align-items: center;
-        padding: calc(0.75rem + env(safe-area-inset-top, 0px)) 1rem 0.75rem 1rem;
-        background: rgba(248, 250, 252, 0.95);
-        border-bottom: 1px solid rgba(15, 23, 42, 0.08);
-        backdrop-filter: blur(6px);
-      }
-
-      #toolbar h1 {
-        margin: 0;
-        font-size: 1rem;
-        font-weight: 600;
-      }
-
-      #toolbar .spacer {
-        flex: 1 1 auto;
-      }
-
-      #toolbar button,
-      #toolbar input,
-      #toolbar select,
-      #toolbar a {
-        font: inherit;
-        border: 1px solid rgba(15, 23, 42, 0.12);
-        border-radius: 0.5rem;
-        background: white;
-        color: inherit;
-        padding: 0.35rem 0.75rem;
-        line-height: 1.2;
-        min-height: 2.25rem;
-        transition: background-color 0.2s ease, border-color 0.2s ease;
-      }
-
-      #toolbar button,
-      #toolbar a {
-        cursor: pointer;
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        gap: 0.25rem;
-      }
-
-      #toolbar button:hover,
-      #toolbar button:focus-visible,
-      #toolbar a:hover,
-      #toolbar a:focus-visible {
-        background-color: rgba(15, 23, 42, 0.06);
-        border-color: rgba(15, 23, 42, 0.18);
-        outline: none;
-      }
-
-      #toolbar input[type='number'] {
-        width: 4.5rem;
-      }
-
-      #toolbar input[type='search'] {
-        width: clamp(12rem, 40vw, 18rem);
-      }
-
+      :root { color-scheme: light dark; }
+      html, body { height: 100%; margin: 0; }
+      /* contenedor ocupa todo el alto del iframe */
       #viewerContainer {
         position: relative;
-        flex: 1 1 auto;
+        height: 100dvh;
         overflow: auto;
         -webkit-overflow-scrolling: touch;
-        scroll-behavior: smooth;
-        scrollbar-gutter: stable;
-        background: #f1f5f9;
-        touch-action: pan-y pinch-zoom;
+        overscroll-behavior: contain;
+        background: var(--pdfjs-viewer-bg, #f6f7f9);
       }
-
-      #viewer {
-        padding: 1rem;
-      }
-
-      #viewer .page {
-        margin: 0 auto 1rem auto;
-        box-shadow: 0 10px 30px rgba(15, 23, 42, 0.12);
-      }
-
-      #loadingIndicator,
-      #errorBanner {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        padding: 1rem 1.5rem;
-        border-radius: 0.75rem;
-        background: rgba(15, 23, 42, 0.85);
-        color: white;
-        display: none;
-        box-shadow: 0 10px 40px rgba(15, 23, 42, 0.3);
-      }
-
-      #loadingIndicator.active,
-      #errorBanner.active {
+      .toolbar {
+        position: sticky;
+        top: 0;
         display: flex;
+        gap: .5rem;
         align-items: center;
-        gap: 0.75rem;
+        padding: .5rem .75rem;
+        border-bottom: 1px solid rgba(0,0,0,.06);
+        background: color-mix(in oklab, Canvas 92%, transparent);
+        backdrop-filter: blur(6px);
+        z-index: 10;
       }
-
-      #errorBanner {
-        background: rgba(220, 38, 38, 0.9);
-      }
-
-      #findStatus {
-        font-size: 0.875rem;
-        opacity: 0.8;
-        min-width: 6rem;
-        text-align: right;
-      }
-
-      #pageCountDisplay {
-        font-size: 0.9rem;
-        opacity: 0.75;
-      }
-
-      #zoomValue {
-        min-width: 3.5rem;
-        text-align: right;
-        font-variant-numeric: tabular-nums;
-      }
-
-      .sr-only {
-        position: absolute;
-        width: 1px;
-        height: 1px;
-        padding: 0;
-        margin: -1px;
-        overflow: hidden;
-        clip: rect(0, 0, 0, 0);
-        white-space: nowrap;
-        border: 0;
-      }
-
-      .toolbar-group {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-      }
-
-      .toolbar-separator {
-        width: 1px;
-        align-self: stretch;
-        background: rgba(15, 23, 42, 0.12);
-        margin-inline: 0.25rem;
-      }
-
-      @media (max-width: 640px) {
-        #toolbar {
-          padding-inline: 0.75rem;
-        }
-
-        #toolbar input[type='search'] {
-          width: 100%;
-          max-width: 100%;
-        }
-
-        #viewer {
-          padding: 0.5rem;
-        }
-      }
+      .toolbar input[type="search"] { flex: 1; }
+      .pdfViewer { padding: 1rem; }
+      button, input, select { font: inherit; }
     </style>
   </head>
   <body>
-    <div id="toolbar" role="toolbar" aria-label="Controles del visor de PDF">
-      <h1 id="documentTitle">Documento</h1>
-      <div class="spacer" aria-hidden="true"></div>
-      <div class="toolbar-group" role="group" aria-label="Zoom">
-        <button id="zoomOut" type="button" title="Reducir zoom">
-          −
-        </button>
-        <span id="zoomValue" aria-live="polite">100%</span>
-        <button id="zoomIn" type="button" title="Aumentar zoom">
-          +
-        </button>
-      </div>
-      <div class="toolbar-separator" aria-hidden="true"></div>
-      <div class="toolbar-group" role="group" aria-label="Navegación de páginas">
-        <label class="sr-only" for="pageNumber">Número de página</label>
-        <input
-          id="pageNumber"
-          type="number"
-          min="1"
-          value="1"
-          aria-label="Página actual"
-        />
-        <span id="pageCountDisplay" aria-live="polite">/ 1</span>
-      </div>
-      <div class="toolbar-separator" aria-hidden="true"></div>
-      <div class="toolbar-group" role="group" aria-label="Búsqueda">
-        <label class="sr-only" for="findInput">Buscar en el documento</label>
-        <input
-          id="findInput"
-          type="search"
-          placeholder="Buscar…"
-          enterkeyhint="search"
-          aria-label="Buscar en el PDF"
-        />
-        <button id="findPrev" type="button" title="Coincidencia anterior">
-          ↑
-        </button>
-        <button id="findNext" type="button" title="Coincidencia siguiente">
-          ↓
-        </button>
-        <span id="findStatus" aria-live="polite"></span>
-      </div>
-      <div class="toolbar-separator" aria-hidden="true"></div>
-      <a id="downloadButton" href="#" target="_blank" rel="noopener" role="button">
-        Descargar
-      </a>
+    <div class="toolbar">
+      <button id="zoomOut" title="Zoom -">−</button>
+      <span id="scaleLabel">100%</span>
+      <button id="zoomIn" title="Zoom +">+</button>
+      <span style="width:.5rem"></span>
+      <input id="find" type="search" placeholder="Buscar…" />
+      <span style="margin-left:auto"></span>
+      <select id="scale">
+        <option value="auto">Ajuste automático</option>
+        <option value="page-width" selected>Ancho de página</option>
+        <option value="page-fit">Ajustar página</option>
+        <option value="1.0">100%</option>
+        <option value="1.25">125%</option>
+        <option value="1.5">150%</option>
+        <option value="2.0">200%</option>
+      </select>
     </div>
-    <div id="viewerContainer" tabindex="0" aria-live="polite">
+
+    <div id="viewerContainer">
       <div id="viewer" class="pdfViewer"></div>
-      <div id="loadingIndicator" role="status" aria-live="assertive">
-        <span>Cargando documento…</span>
-      </div>
-      <div id="errorBanner" role="alert">
-        <span>No se pudo cargar el PDF.</span>
-      </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.5.136/pdf.min.js" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.5.136/pdf_viewer.min.js" crossorigin="anonymous"></script>
-    <script>
-      (function () {
-        const params = new URLSearchParams(window.location.search);
-        const fileParam = params.get('file');
-        const hashZoom = (window.location.hash || '').split('&').find((part) => part.startsWith('zoom='));
-        const initialZoom = hashZoom ? hashZoom.split('=')[1] : 'page-width';
-        const viewerContainer = document.getElementById('viewerContainer');
-        const viewerElement = document.getElementById('viewer');
-        const pageNumberInput = document.getElementById('pageNumber');
-        const pageCountDisplay = document.getElementById('pageCountDisplay');
-        const zoomValueLabel = document.getElementById('zoomValue');
-        const zoomOutButton = document.getElementById('zoomOut');
-        const zoomInButton = document.getElementById('zoomIn');
-        const findInput = document.getElementById('findInput');
-        const findPrevButton = document.getElementById('findPrev');
-        const findNextButton = document.getElementById('findNext');
-        const findStatus = document.getElementById('findStatus');
-        const downloadButton = document.getElementById('downloadButton');
-        const loadingIndicator = document.getElementById('loadingIndicator');
-        const errorBanner = document.getElementById('errorBanner');
-        const documentTitle = document.getElementById('documentTitle');
+    <script type="module">
+      import * as pdfjsLib from "../build/pdf.mjs";
+      import * as pdfjsViewer from "../build/pdf_viewer.mjs";
 
-        if (!fileParam) {
-          loadingIndicator.classList.remove('active');
-          errorBanner.classList.add('active');
-          errorBanner.textContent = 'Sin documento para mostrar.';
-          return;
-        }
+      // Worker local
+      pdfjsLib.GlobalWorkerOptions.workerSrc = "../build/pdf.worker.mjs";
 
-        const decodedFile = decodeURIComponent(fileParam);
-        documentTitle.textContent = decodedFile.split('/').pop() || 'Documento';
-        downloadButton.href = decodedFile;
+      // Parámetro ?file= (URL ya firmada S3)
+      const params = new URLSearchParams(location.search);
+      const fileUrl = params.get("file");
+      if (!fileUrl) {
+        document.getElementById("viewer").innerHTML =
+          "<p style='padding:16px;color:#777'>Sin archivo.</p>";
+        throw new Error("Missing ?file param");
+      }
 
-        pdfjsLib.GlobalWorkerOptions.workerSrc = 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.5.136/pdf.worker.min.js';
+      const eventBus = new pdfjsViewer.EventBus();
+      const linkService = new pdfjsViewer.PDFLinkService({ eventBus });
+      const findController = new pdfjsViewer.PDFFindController({
+        eventBus,
+        linkService,
+      });
 
-        const eventBus = new pdfjsViewer.EventBus();
-        const linkService = new pdfjsViewer.PDFLinkService({ eventBus });
-        const findController = new pdfjsViewer.PDFFindController({ eventBus, linkService });
+      const container = document.getElementById("viewerContainer");
+      const viewer = new pdfjsViewer.PDFViewer({
+        container,
+        eventBus,
+        linkService,
+        findController,
+      });
+      linkService.setViewer(viewer);
 
-        const pdfViewer = new pdfjsViewer.PDFViewer({
-          container: viewerContainer,
-          eventBus,
-          linkService,
-          findController,
-          l10n: pdfjsViewer.NullL10n,
-          useOnlyCssZoom: false,
-          textLayerMode: 1,
-          annotationMode: 2,
+      eventBus.on("pagesinit", () => {
+        viewer.currentScaleValue = "page-width";
+      });
+
+      // Controles básicos
+      const scaleEl = document.getElementById("scale");
+      const scaleLabel = document.getElementById("scaleLabel");
+      const zoomIn = document.getElementById("zoomIn");
+      const zoomOut = document.getElementById("zoomOut");
+      const findEl = document.getElementById("find");
+
+      const updateScaleLabel = () => {
+        scaleLabel.textContent = `${Math.round(viewer.currentScale * 100)}%`;
+      };
+
+      zoomIn.addEventListener("click", () => {
+        viewer.currentScale = viewer.currentScale * 1.1;
+        updateScaleLabel();
+      });
+      zoomOut.addEventListener("click", () => {
+        viewer.currentScale = viewer.currentScale / 1.1;
+        updateScaleLabel();
+      });
+      scaleEl.addEventListener("change", () => {
+        viewer.currentScaleValue = scaleEl.value;
+        updateScaleLabel();
+      });
+      findEl.addEventListener("input", () => {
+        eventBus.dispatch("find", {
+          type: "",
+          query: findEl.value,
+          caseSensitive: false,
+          entireWord: false,
+          highlightAll: true,
+          phraseSearch: true,
+          findPrevious: false,
         });
+      });
 
-        linkService.setViewer(pdfViewer);
-
-        function setLoading(isLoading) {
-          if (isLoading) {
-            loadingIndicator.classList.add('active');
-            errorBanner.classList.remove('active');
-          } else {
-            loadingIndicator.classList.remove('active');
-          }
-        }
-
-        function updateZoomValue(value) {
-          const percent = Math.round(value * 100);
-          zoomValueLabel.textContent = `${percent}%`;
-        }
-
-        function updatePageNumber(pageNumber) {
-          pageNumberInput.value = pageNumber;
-        }
-
-        function executeFind(command) {
-          const query = findInput.value.trim();
-          if (!query) {
-            findStatus.textContent = '';
-            return;
-          }
-          findController.executeCommand(command, {
-            query,
-            phraseSearch: true,
-            highlightAll: true,
-            findPrevious: command === 'findprevious',
-          });
-        }
-
-        eventBus.on('pagesinit', () => {
-          pdfViewer.currentScaleValue = initialZoom || 'page-width';
-          updateZoomValue(pdfViewer.currentScale);
-          updatePageNumber(pdfViewer.currentPageNumber);
-          viewerContainer.focus({ preventScroll: true });
-        });
-
-        eventBus.on('pagechanging', (evt) => {
-          updatePageNumber(evt.pageNumber);
-        });
-
-        eventBus.on('scalechanging', (evt) => {
-          updateZoomValue(evt.scale);
-        });
-
-        eventBus.on('textlayerrendered', () => {
-          if (!findInput.value.trim()) {
-            findStatus.textContent = '';
-          }
-        });
-
-        findController.onUpdateResultsCount = (matchCount) => {
-          if (matchCount.total) {
-            findStatus.textContent = `${matchCount.current}/${matchCount.total}`;
-          } else {
-            findStatus.textContent = '0/0';
-          }
-        };
-
-        findController.onUpdateState = (state, previous, matchesOutOfDate) => {
-          if (matchesOutOfDate) {
-            findStatus.textContent = '…';
-          } else if (state === pdfjsViewer.FindState.FOUND) {
-            findStatus.textContent = findStatus.textContent || '1/1';
-          } else if (state === pdfjsViewer.FindState.NOT_FOUND) {
-            findStatus.textContent = '0/0';
-          }
-        };
-
-        setLoading(true);
-        const loadingTask = pdfjsLib.getDocument({ url: decodedFile, withCredentials: true });
-        loadingTask.promise
-          .then((pdfDocument) => {
-            pdfViewer.setDocument(pdfDocument);
-            linkService.setDocument(pdfDocument, null);
-            findController.setDocument(pdfDocument);
-            pageCountDisplay.textContent = `/ ${pdfDocument.numPages}`;
-            setLoading(false);
-          })
-          .catch((error) => {
-            console.error('PDF load error', error);
-            setLoading(false);
-            errorBanner.classList.add('active');
-            errorBanner.textContent = 'No se pudo cargar el PDF.';
-          });
-
-        zoomOutButton.addEventListener('click', () => {
-          const newScale = pdfViewer.currentScale * 0.9;
-          pdfViewer.currentScale = Math.max(newScale, 0.1);
-        });
-
-        zoomInButton.addEventListener('click', () => {
-          const newScale = pdfViewer.currentScale * 1.1;
-          pdfViewer.currentScale = Math.min(newScale, 5);
-        });
-
-        pageNumberInput.addEventListener('change', () => {
-          const value = parseInt(pageNumberInput.value, 10);
-          if (!Number.isNaN(value)) {
-            const clamped = Math.min(Math.max(value, 1), pdfViewer.pagesCount || 1);
-            pdfViewer.currentPageNumber = clamped;
-            updatePageNumber(clamped);
-          }
-        });
-
-        findInput.addEventListener('keydown', (event) => {
-          if (event.key === 'Enter') {
-            event.preventDefault();
-            executeFind('find');
-          }
-        });
-
-        findNextButton.addEventListener('click', () => {
-          executeFind('findagain');
-        });
-
-        findPrevButton.addEventListener('click', () => {
-          executeFind('findprevious');
-        });
-
-        viewerContainer.addEventListener(
-          'wheel',
-          (event) => {
-            if (event.ctrlKey) {
-              event.preventDefault();
-              const delta = event.deltaY < 0 ? 1.1 : 0.9;
-              const newScale = pdfViewer.currentScale * delta;
-              pdfViewer.currentScale = Math.min(Math.max(newScale, 0.1), 5);
-            }
-          },
-          { passive: false },
-        );
-
-        window.addEventListener('keydown', (event) => {
-          if (!event.ctrlKey && !event.metaKey) return;
-          if (event.key === '+') {
-            event.preventDefault();
-            zoomInButton.click();
-          }
-          if (event.key === '-') {
-            event.preventDefault();
-            zoomOutButton.click();
-          }
-          if (event.key.toLowerCase() === 'f') {
-            event.preventDefault();
-            findInput.focus();
-            findInput.select();
-          }
-        });
-      })();
+      const loadingTask = pdfjsLib.getDocument(fileUrl);
+      const pdf = await loadingTask.promise;
+      viewer.setDocument(pdf);
+      linkService.setDocument(pdf);
     </script>
   </body>
 </html>

--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -58,7 +58,6 @@ export default function DocumentDetailPage() {
   const [rejectOpen, setRejectOpen] = useState(false);
   const [rejectReason, setRejectReason] = useState('');
   const [downloading, setDownloading] = useState(false);
-  const [refreshingLinks, setRefreshingLinks] = useState(false);
   const [activeTab, setActiveTab] = useState<DocumentTabValue>('firmas');
   const summaryDialogRef = useRef<DocumentSummaryDialogHandle>(null);
 
@@ -163,23 +162,6 @@ export default function DocumentDetailPage() {
     setRejectOpen(false);
   };
 
-  const handleRefreshLinks = async () => {
-    if (!detalle?.id || refreshingLinks) return;
-    try {
-      setRefreshingLinks(true);
-      const updated = await getCuadroFirmaDetalle(detalle.id, 3600);
-      setDetalle((prev) => (prev ? { ...prev, ...updated } : updated));
-    } catch (error) {
-      toast({
-        variant: 'destructive',
-        title: 'Error',
-        description: 'No se pudo actualizar el vínculo del documento.',
-      });
-    } finally {
-      setRefreshingLinks(false);
-    }
-  };
-
   const handleSummarize = () => {
     if (!detalle) return;
     summaryDialogRef.current?.open();
@@ -265,13 +247,11 @@ export default function DocumentDetailPage() {
         <div className="mt-4 grid grid-cols-12 gap-4">
           <div className="col-span-12 md:col-span-8 xl:col-span-9">
             <div
-              className="h-[calc(100dvh-var(--app-header-h)-16px)] overflow-auto overscroll-y-contain touch-pan-y [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch]"
+              className="h-[calc(100dvh-var(--app-header-h)-theme(spacing.10))] overflow-auto overscroll-y-contain touch-pan-y [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch]"
             >
               <DocumentTabs
                 urlCuadroFirmasPDF={detalle.urlCuadroFirmasPDF}
                 urlDocumento={detalle.urlDocumento}
-                onRefreshLinks={handleRefreshLinks}
-                isRefreshingLinks={refreshingLinks}
                 onTabChange={setActiveTab}
               />
             </div>

--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -11,7 +11,7 @@ import React, {
 import ReactMarkdown from 'react-markdown';
 import { Loader2, Copy, Download, Play, Pause, Square } from 'lucide-react';
 
-import { SmartPDFViewer } from '@/components/document/SmartPDFViewer';
+import SmartPDFViewer from '@/components/document/SmartPDFViewer';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -413,8 +413,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
       };
     }, [stopTTS]);
 
-    const pdfUrl = docData?.urlDocumento ?? docData?.urlCuadroFirmasPDF ?? '';
-    const viewerTitle = docData?.titulo ?? 'Documento';
+    const pdfUrl = docData?.urlDocumento ?? docData?.urlCuadroFirmasPDF ?? null;
 
     return (
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
@@ -424,9 +423,11 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
           </DialogHeader>
           <div className="flex flex-col gap-4 p-4 lg:flex-row">
             <div className="w-full lg:w-1/2">
-              <div className="h-[calc(100dvh-220px)] overflow-auto overscroll-y-contain touch-pan-y [scrollbar-gutter:stable]">
-                <SmartPDFViewer src={pdfUrl || undefined} title={viewerTitle} className="h-full" />
-              </div>
+              <SmartPDFViewer
+                srcPdf={pdfUrl}
+                className="h-[min(70vh,calc(100dvh-12rem))]"
+                openLabel="Abrir documento"
+              />
             </div>
             <div className="w-full flex flex-col gap-3 lg:w-1/2">
               <div className="flex flex-wrap items-center justify-end gap-2">

--- a/src/components/document-detail/pdf-viewer.tsx
+++ b/src/components/document-detail/pdf-viewer.tsx
@@ -1,15 +1,13 @@
 "use client";
 
-import React from 'react';
-
-import { SmartPDFViewer } from '@/components/document/SmartPDFViewer';
+import SmartPDFViewer from '@/components/document/SmartPDFViewer';
 
 type DocumentPdfViewerProps = {
   pdfUrl?: string | null;
-  title?: string;
   className?: string;
+  openLabel?: string;
 };
 
-export function DocumentPdfViewer({ pdfUrl, title, className }: DocumentPdfViewerProps) {
-  return <SmartPDFViewer src={pdfUrl ?? undefined} title={title} className={className} />;
+export function DocumentPdfViewer({ pdfUrl, className, openLabel }: DocumentPdfViewerProps) {
+  return <SmartPDFViewer srcPdf={pdfUrl ?? null} className={className} openLabel={openLabel} />;
 }

--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -4,23 +4,19 @@ import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { SmartPDFViewer } from "./SmartPDFViewer";
+import SmartPDFViewer from "./SmartPDFViewer";
 
 export type DocumentTabValue = "firmas" | "original";
 
 type DocumentTabsProps = {
   urlCuadroFirmasPDF?: string | null;
   urlDocumento?: string | null;
-  onRefreshLinks: () => Promise<void>;
-  isRefreshingLinks?: boolean;
   onTabChange?: (tab: DocumentTabValue) => void;
 };
 
 export function DocumentTabs({
   urlCuadroFirmasPDF,
   urlDocumento,
-  onRefreshLinks,
-  isRefreshingLinks = false,
   onTabChange,
 }: DocumentTabsProps) {
   const [activeTab, setActiveTab] = useState<DocumentTabValue>("firmas");
@@ -99,23 +95,11 @@ export function DocumentTabs({
       </div>
 
       <TabsContent value="firmas" className="mt-0 flex flex-1 flex-col">
-        <SmartPDFViewer
-          title="Cuadro de firmas"
-          src={urlCuadroFirmasPDF ?? undefined}
-          onRefresh={onRefreshLinks}
-          isRefreshing={isRefreshingLinks}
-          className="flex-1"
-        />
+        <SmartPDFViewer srcPdf={urlCuadroFirmasPDF ?? null} className="flex-1" />
       </TabsContent>
 
       <TabsContent value="original" className="mt-0 flex flex-1 flex-col">
-        <SmartPDFViewer
-          title="Documento original"
-          src={urlDocumento ?? undefined}
-          onRefresh={onRefreshLinks}
-          isRefreshing={isRefreshingLinks}
-          className="flex-1"
-        />
+        <SmartPDFViewer srcPdf={urlDocumento ?? null} className="flex-1" />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/document/SmartPDFViewer.tsx
+++ b/src/components/document/SmartPDFViewer.tsx
@@ -1,218 +1,78 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ExternalLink, Loader2, RefreshCcw } from "lucide-react";
+import { useMemo } from "react";
 
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-type ViewerStatus = "idle" | "loading" | "success" | "failed" | "empty";
-
-type SmartPDFViewerProps = {
-  src?: string | null;
-  title?: string;
+type Props = {
+  /** URL absoluta del PDF (S3 firmado) */
+  srcPdf: string | null | undefined;
   className?: string;
-  /** Callback that refreshes the presigned URL links */
-  onRefresh?: () => Promise<void> | void;
-  /** Indicates whether the parent component is already refreshing the links */
-  isRefreshing?: boolean;
-  /** Timeout in milliseconds before declaring the iframe failed */
-  timeoutMs?: number;
+  /** Texto del botón abrir en nueva pestaña (iOS) */
+  openLabel?: string;
 };
 
-const IOS_PLATFORM_REGEX = /\b(iPad|iPhone|iPod)\b/i;
+export default function SmartPDFViewer({ srcPdf, className, openLabel = "Abrir en nueva pestaña" }: Props) {
+  const isIOS =
+    typeof navigator !== "undefined" &&
+    /iPad|iPhone|iPod/.test(navigator.userAgent) &&
+    !(window as any).MSStream;
 
-function detectIOS(): boolean {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
+  const viewerSrc = useMemo(() => {
+    if (!srcPdf) return null;
+    const file = encodeURIComponent(srcPdf);
+    // Usamos nuestro viewer local
+    return `/pdfjs/web/viewer.html?file=${file}`;
+  }, [srcPdf]);
 
-  const platform = navigator.platform ?? "";
-  const userAgent = navigator.userAgent ?? "";
-  const isIOSDevice = IOS_PLATFORM_REGEX.test(platform) || IOS_PLATFORM_REGEX.test(userAgent);
-  const isIpadOs = navigator.maxTouchPoints > 1 && /Macintosh/.test(userAgent);
-
-  return isIOSDevice || isIpadOs;
-}
-
-export function SmartPDFViewer({
-  src,
-  title,
-  className,
-  onRefresh,
-  isRefreshing = false,
-  timeoutMs = 6000,
-}: SmartPDFViewerProps) {
-  const [status, setStatus] = useState<ViewerStatus>(() => (!src ? "empty" : "loading"));
-  const timeoutRef = useRef<number>();
-  const autoRefreshRef = useRef(false);
-  const [isIOS, setIsIOS] = useState(false);
-
-  const viewerUrl = useMemo(() => {
-    if (!src) return undefined;
-    const encoded = encodeURIComponent(src);
-    return `/pdfjs/web/viewer.html?file=${encoded}#zoom=page-width`;
-  }, [src]);
-
-  useEffect(() => {
-    setIsIOS(detectIOS());
-  }, []);
-
-  useEffect(() => {
-    if (!src) {
-      setStatus("empty");
-      return;
-    }
-
-    setStatus("loading");
-    autoRefreshRef.current = false;
-
-    if (timeoutMs <= 0) {
-      return;
-    }
-
-    timeoutRef.current = window.setTimeout(() => {
-      setStatus((previous) => {
-        if (previous === "loading") {
-          if (onRefresh && !autoRefreshRef.current) {
-            autoRefreshRef.current = true;
-            void Promise.resolve(onRefresh()).catch(() => undefined);
-          }
-          return "failed";
-        }
-        return previous;
-      });
-    }, timeoutMs);
-
-    return () => {
-      if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
-      }
-    };
-  }, [onRefresh, src, timeoutMs]);
-
-  const handleLoad = useCallback(() => {
-    if (timeoutRef.current) {
-      window.clearTimeout(timeoutRef.current);
-    }
-    setStatus("success");
-  }, []);
-
-  const handleError = useCallback(() => {
-    if (timeoutRef.current) {
-      window.clearTimeout(timeoutRef.current);
-    }
-    setStatus("failed");
-  }, []);
-
-  const handleManualRefresh = useCallback(async () => {
-    if (!onRefresh) return;
-    setStatus("loading");
-    autoRefreshRef.current = true;
-    try {
-      await onRefresh();
-    } catch (error) {
-      setStatus("failed");
-    }
-  }, [onRefresh]);
-
-  const handleOpenInNewTab = useCallback(() => {
-    if (!src) return;
-    window.open(src, "_blank", "noopener,noreferrer");
-  }, [src]);
-
-  const containerClass = cn(
-    "relative block h-full w-full overflow-auto rounded-xl border bg-background",
-    "overscroll-y-contain touch-pan-y [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch]",
-    className,
-  );
-
-  if (status === "empty") {
+  if (!srcPdf) {
     return (
-      <div className={containerClass} role="document" aria-label={title ?? "Visor de PDF"}>
-        <div className="flex h-full w-full items-center justify-center text-sm text-muted-foreground">
-          Sin vista disponible
-        </div>
-      </div>
-    );
-  }
-
-  if (status === "failed") {
-    return (
-      <div className={containerClass} role="document" aria-label={title ?? "Visor de PDF"}>
-        <div className="flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center">
-          <p className="text-sm text-muted-foreground">No se pudo cargar el PDF.</p>
-          {onRefresh && (
-            <Button
-              variant="outline"
-              onClick={handleManualRefresh}
-              disabled={isRefreshing}
-              className="flex items-center gap-2"
-            >
-              {isRefreshing ? (
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-              ) : (
-                <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-              )}
-              Actualizar vínculo
-            </Button>
-          )}
-          {src && (
-            <Button variant="ghost" size="sm" onClick={handleOpenInNewTab} className="flex items-center gap-2">
-              <ExternalLink className="h-4 w-4" aria-hidden="true" />
-              Abrir en pestaña nueva
-            </Button>
-          )}
-        </div>
+      <div
+        className={cn(
+          "relative w-full rounded-xl border bg-background text-muted-foreground grid place-items-center",
+          "min-h-[60vh]",
+          className,
+        )}
+      >
+        Sin vista disponible
       </div>
     );
   }
 
   return (
     <div
-      className={containerClass}
-      role="document"
-      aria-label={title ?? "Visor de PDF"}
-      aria-busy={status === "loading"}
+      className={cn(
+        "relative w-full rounded-xl border bg-background",
+        // contenedor scroll propio para no pelear con la página
+        "h-[calc(100dvh-var(--app-header-h)-theme(spacing.24))] md:h-[calc(100dvh-var(--app-header-h)-theme(spacing.16))]",
+        "overflow-auto overscroll-y-contain touch-pan-y",
+        className,
+      )}
     >
-      {viewerUrl && (
+      {/* iOS: ofrecer abrir en nueva pestaña (mejor experiencia en algunos WKWebView) */}
+      {isIOS && viewerSrc && (
+        <a
+          href={viewerSrc}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute bottom-3 right-3 z-20 rounded-xl border bg-background/80 px-3 py-2 text-sm shadow"
+        >
+          {openLabel}
+        </a>
+      )}
+
+      {viewerSrc && (
         <iframe
-          key={viewerUrl}
-          title={title ?? "Visor de PDF"}
-          src={viewerUrl}
+          title="Visor de PDF"
+          src={viewerSrc}
           className="block h-full w-full"
           referrerPolicy="no-referrer"
+          // ⚠ Quitar allowFullScreen para evitar el warning
           allow="fullscreen"
-          allowFullScreen
-          onLoad={handleLoad}
-          onError={handleError}
+          // Sandbox mínimo para el visor (scripts + same-origin para worker)
+          sandbox="allow-scripts allow-same-origin allow-downloads allow-popups"
         />
-      )}
-
-      {status === "loading" && (
-        <div className="absolute inset-0 flex items-center justify-center bg-background/80" aria-live="polite">
-          <div className="flex flex-col items-center gap-3 text-sm text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
-            <span>{isRefreshing ? "Actualizando vínculo..." : "Cargando documento..."}</span>
-          </div>
-        </div>
-      )}
-
-      {isIOS && src && (
-        <Button
-          type="button"
-          size="icon"
-          variant="secondary"
-          className="absolute bottom-3 right-3 h-9 w-9 rounded-full shadow-md"
-          onClick={handleOpenInNewTab}
-          title="Abrir en una pestaña nueva"
-        >
-          <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          <span className="sr-only">Abrir en pestaña nueva</span>
-        </Button>
       )}
     </div>
   );
 }
-
-export default SmartPDFViewer;


### PR DESCRIPTION
## Summary
- add a local PDF.js viewer page and SmartPDFViewer wrapper to confine scrolling across desktop and mobile
- update document tabs, summary dialog, and proxy wrapper to use the unified viewer with correct heights
- add a prepare script for bundling pdf.js assets and expose the build folder in gitignore

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5af784eac8332baf492748d07d2eb