### PR TITLE
Use native PDF viewer for document detail and fix mobile footer

### DIFF
--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -247,7 +247,7 @@ export default function DocumentDetailPage() {
         <div className="mt-4 grid grid-cols-12 gap-4">
           <div className="col-span-12 md:col-span-8 xl:col-span-9">
             <div
-              className="h-[calc(100dvh-var(--app-header-h)-theme(spacing.10))] overflow-auto overscroll-y-contain touch-pan-y [scrollbar-gutter:stable] [-webkit-overflow-scrolling:touch]"
+              className="h-[calc(100dvh-var(--app-header-h)-theme(spacing.10))] min-h-0 overflow-hidden pb-[calc(env(safe-area-inset-bottom)+88px)] md:pb-0"
             >
               <DocumentTabs
                 urlCuadroFirmasPDF={detalle.urlCuadroFirmasPDF}
@@ -313,47 +313,49 @@ export default function DocumentDetailPage() {
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-            <div className="flex gap-2">
-              <Button
-                onClick={handleSign}
-                className="flex-1"
-                disabled={!canSign}
-                title={blockMessage}
-              >
-                Firmar
-              </Button>
-              <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
+            <div className="md:static sticky bottom-0 z-20 mt-4 border-t bg-background/80 px-3 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+              <div className="flex gap-2">
                 <Button
-                  variant="destructive"
+                  onClick={handleSign}
                   className="flex-1"
-                  onClick={() => setRejectOpen(true)}
                   disabled={!canSign}
+                  title={blockMessage}
                 >
-                  Rechazar
+                  Firmar
                 </Button>
-                <DialogContent aria-describedby="reject-desc">
-                  <DialogHeader>
-                    <DialogTitle>Motivo del rechazo</DialogTitle>
-                    <DialogDescription id="reject-desc">
-                      Describa el motivo del rechazo del documento.
-                    </DialogDescription>
-                  </DialogHeader>
-                  <Textarea value={rejectReason} onChange={(e) => setRejectReason(e.target.value)} />
-                  <DialogFooter>
-                    <DialogCloseButton
-                      variant="secondary"
-                      onClick={() => setRejectOpen(false)}
-                    >
-                      Cancelar
-                    </DialogCloseButton>
-                    <Button onClick={handleReject}>Enviar</Button>
-                  </DialogFooter>
-                </DialogContent>
-              </Dialog>
+                <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
+                  <Button
+                    variant="destructive"
+                    className="flex-1"
+                    onClick={() => setRejectOpen(true)}
+                    disabled={!canSign}
+                  >
+                    Rechazar
+                  </Button>
+                  <DialogContent aria-describedby="reject-desc">
+                    <DialogHeader>
+                      <DialogTitle>Motivo del rechazo</DialogTitle>
+                      <DialogDescription id="reject-desc">
+                        Describa el motivo del rechazo del documento.
+                      </DialogDescription>
+                    </DialogHeader>
+                    <Textarea value={rejectReason} onChange={(e) => setRejectReason(e.target.value)} />
+                    <DialogFooter>
+                      <DialogCloseButton
+                        variant="secondary"
+                        onClick={() => setRejectOpen(false)}
+                      >
+                        Cancelar
+                      </DialogCloseButton>
+                      <Button onClick={handleReject}>Enviar</Button>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
+              </div>
+              {!canSign && blockMessage && (
+                <p className="mt-2 text-xs text-muted-foreground">{blockMessage}</p>
+              )}
             </div>
-            {!canSign && blockMessage && (
-              <p className="text-xs text-muted-foreground">{blockMessage}</p>
-            )}
             {activeTab === 'original' && (
               <div className="pt-4 space-y-2">
                 <div className="flex items-center gap-2">

--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState, type CSSProperties } from "react";
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import SmartPDFViewer from "./SmartPDFViewer";
+import NativePDF from "./NativePDF";
 
 export type DocumentTabValue = "firmas" | "original";
 
@@ -94,12 +94,12 @@ export function DocumentTabs({
         </TabsList>
       </div>
 
-      <TabsContent value="firmas" className="mt-0 flex flex-1 flex-col">
-        <SmartPDFViewer srcPdf={urlCuadroFirmasPDF ?? null} className="flex-1" />
+      <TabsContent value="firmas" className="mt-0 h-full overflow-hidden data-[state=inactive]:hidden">
+        <NativePDF src={urlCuadroFirmasPDF ?? null} className="h-full" />
       </TabsContent>
 
-      <TabsContent value="original" className="mt-0 flex flex-1 flex-col">
-        <SmartPDFViewer srcPdf={urlDocumento ?? null} className="flex-1" />
+      <TabsContent value="original" className="mt-0 h-full overflow-hidden data-[state=inactive]:hidden">
+        <NativePDF src={urlDocumento ?? null} className="h-full" />
       </TabsContent>
     </Tabs>
   );

--- a/src/components/document/NativePDF.tsx
+++ b/src/components/document/NativePDF.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export default function NativePDF({
+  src,
+  className,
+  openLabel = "Abrir en nueva pestaña",
+}: { src: string | null | undefined; className?: string; openLabel?: string }) {
+  const isIOS = typeof navigator !== "undefined" && /iPad|iPhone|iPod/.test(navigator.userAgent);
+  if (!src) {
+    return (
+      <div className={cn("grid min-h-[240px] place-items-center rounded-xl border text-sm text-muted-foreground", className)}>
+        Sin vista disponible
+      </div>
+    );
+  }
+  return (
+    <div className={cn("relative min-h-0 w-full flex-1 overflow-hidden rounded-xl border bg-background", className)}>
+      {isIOS && (
+        <a
+          href={src}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="absolute bottom-3 right-3 z-20 rounded-xl border bg-background/80 px-3 py-2 text-sm shadow"
+        >
+          {openLabel}
+        </a>
+      )}
+      {/* Visor nativo (Chrome/Edge/Firefox) o QuickLook (iOS) */}
+      <object data={src} type="application/pdf" className="h-full w-full">
+        <iframe src={src} className="h-full w-full" title="PDF" />
+      </object>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable NativePDF component that wraps the browser PDF viewer and exposes an iOS open-in-new-tab button
- replace SmartPDFViewer usage in the document tabs with the native viewer while preventing hidden tab scroll bleed
- adjust the document detail layout to reserve space for the sticky mobile action footer

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b9843f008332bbf2799a29a8a6e9