### PR TITLE
Fix mobile PDF viewer scrolling behavior

### DIFF
--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -439,9 +439,18 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
           <div className="px-6 pb-6">
             <div className="flex flex-col gap-4 lg:flex-row">
               <div className="w-full lg:w-1/2">
-                {/* Contenedor del visor: altura fija; el scroll debe ocurrir DENTRO del iframe */}
-                <div className="h-[min(75vh,calc(100dvh-12rem))] w-full lg:h-[calc(100dvh-16rem)]">
-                  <SmartPDFViewer src={pdfUrl ?? undefined} openLabel="Abrir documento" />
+                <div
+                  className="w-full"
+                  style={{
+                    height: "min(75vh, calc(100dvh - 12rem))",
+                    overflow: "hidden",
+                  }}
+                >
+                  <SmartPDFViewer
+                    src={pdfUrl ?? undefined}
+                    openLabel="Abrir documento"
+                    className="h-full w-full"
+                  />
                 </div>
               </div>
 

--- a/src/components/document-detail/pdf-viewer.tsx
+++ b/src/components/document-detail/pdf-viewer.tsx
@@ -13,8 +13,14 @@ export function DocumentPdfViewer({
   openLabel?: string;
 }) {
   return (
-    <div className={cn("h-[calc(100dvh-220px)] w-full", className)}>
-      <SmartPDFViewer src={pdfUrl ?? null} openLabel={openLabel} />
+    <div
+      className={cn("w-full", className)}
+      style={{
+        height: "calc(100dvh - 220px)",
+        overflow: "hidden",
+      }}
+    >
+      <SmartPDFViewer src={pdfUrl ?? null} openLabel={openLabel} className="h-full w-full" />
     </div>
   );
 }

--- a/src/components/document/SmartPDFViewer.tsx
+++ b/src/components/document/SmartPDFViewer.tsx
@@ -4,6 +4,11 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
+const isIOS =
+  typeof navigator !== "undefined" &&
+  (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
+
 type SmartPDFViewerProps = {
   src?: string | null;
   srcPdf?: string | null;
@@ -20,11 +25,9 @@ export function SmartPDFViewer({
   title,
 }: SmartPDFViewerProps) {
   const resolvedSrc = React.useMemo(() => src ?? srcPdf ?? null, [src, srcPdf]);
-  const [loaded, setLoaded] = React.useState(false);
   const [errored, setErrored] = React.useState(false);
 
   React.useEffect(() => {
-    setLoaded(false);
     setErrored(false);
   }, [resolvedSrc]);
 
@@ -53,21 +56,47 @@ export function SmartPDFViewer({
 
   return (
     <div
-      className={cn("relative h-full w-full touch-pan-y overscroll-contain", className)}
-      style={{ WebkitOverflowScrolling: "touch" }}
-      data-loaded={loaded ? "true" : "false"}
+      className={cn("relative h-full w-full", className)}
+      style={{
+        overflow: "auto",
+        overscrollBehavior: "contain",
+        WebkitOverflowScrolling: "touch",
+        touchAction: "pan-y",
+      }}
     >
-      <iframe
-        key={resolvedSrc}
-        src={resolvedSrc}
-        title={title ?? "PDF"}
-        className="block h-full w-full border-0"
-        loading="lazy"
-        referrerPolicy="no-referrer-when-downgrade"
-        scrolling="yes"
-        onLoad={() => setLoaded(true)}
-        onError={() => setErrored(true)}
-      />
+      {isIOS ? (
+        <object
+          key={`${resolvedSrc}#obj`}
+          data={resolvedSrc}
+          type="application/pdf"
+          title={title ?? "PDF"}
+          className="block h-full w-full"
+          onError={() => setErrored(true)}
+        >
+          <div className="grid h-full place-items-center p-4">
+            <a
+              href={resolvedSrc}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="rounded-lg border bg-background px-3 py-2 text-sm shadow"
+            >
+              {openLabel}
+            </a>
+          </div>
+        </object>
+      ) : (
+        <iframe
+          key={resolvedSrc}
+          src={resolvedSrc}
+          title={title ?? "PDF"}
+          className="block h-full w-full border-0"
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          scrolling="yes"
+          onError={() => setErrored(true)}
+        />
+      )}
+
       <div className="pointer-events-none absolute bottom-3 right-3">
         <a
           href={resolvedSrc}


### PR DESCRIPTION
## Summary
- update SmartPDFViewer to use an iOS-specific <object> embed with mobile-friendly scrolling styles and preserve the quick action fallback
- ensure document detail PDF viewer reserves a dvh-based height and delegates scrolling to the embedded viewer
- adjust the document summary dialog viewer container to provide a fixed height with internal scrolling handled by SmartPDFViewer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64109b37c83328896be702b1b2cd4