### PR TITLE
feat: refresh admin layout branding and sidebar

### DIFF
--- a/public/brand/logo-full.svg
+++ b/public/brand/logo-full.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="80" viewBox="0 0 200 80" role="img" aria-label="Génesis Sign">
+  <title>Génesis Sign</title>
+  <image href="/genesissign.png" width="200" height="80" preserveAspectRatio="xMidYMid meet" />
+</svg>

--- a/public/brand/logo-mark.svg
+++ b/public/brand/logo-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Génesis Sign">
+  <title>Génesis Sign</title>
+  <image href="/genesissignlogotipo.png" width="64" height="64" preserveAspectRatio="xMidYMid meet" />
+</svg>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,20 +1,8 @@
 "use client";
 
-import React, { useEffect } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
-import {
-  FileIcon,
-  FilePlus2,
-  FileText,
-  FolderKanban,
-  Key,
-  LogOut,
-  PanelLeft,
-  Settings,
-  ShieldCheck,
-  ShieldIcon,
-  Users,
-} from 'lucide-react';
+import { LogOut, Settings } from 'lucide-react';
 
 import { AuthGuard } from '@/components/auth-guard';
 import { NotificationBell } from '@/components/notifications/NotificationBell';
@@ -33,34 +21,11 @@ import { useToast } from '@/hooks/use-toast';
 import { initials } from '@/lib/avatar';
 import { useSession } from '@/lib/session';
 
-import { AppLayout, useSidebarSheet } from '@/components/layout/AppLayout';
-import { Header } from '@/components/layout/Header';
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarMenuSkeleton,
-} from '@/components/layout/Sidebar';
+import { LayoutShell } from '@/components/layout/LayoutShell';
+import { TopBar } from '@/components/layout/TopBar';
+import { type SidebarItem } from '@/components/layout/AppSidebar';
 
-type AdminRoute = {
-  key: string;
-  label: string;
-  href: string;
-  Icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
-};
-
-interface AdminSidebarProps {
-  routes: AdminRoute[];
-  pathname: string;
-  isLoading: boolean;
-  onNavigate: (href: string) => void;
-}
-
-export default function AdminLayout({ children }: { children: React.ReactNode }) {
+export default function AdminLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const router = useRouter();
 
@@ -91,30 +56,24 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     }
   }, [error, router, toast]);
 
-  const iconMap: Record<string, any> = {
-    FilePlus2,
-    FolderKanban,
-    FileText,
-    Users,
-    Key,
-    FileIcon,
-    ShieldIcon,
-    ShieldCheck,
-  };
+  const adminPages = pages.filter((p: any) => p.path?.startsWith('/admin'));
+  const sortedAdminPages = [...adminPages].sort(
+    (a: any, b: any) => (a.order ?? a.id) - (b.order ?? b.id)
+  );
 
-  const adminPages = pages.filter((p: any) => p.path.startsWith('/admin'));
-  const routes: AdminRoute[] = adminPages
-    .sort((a: any, b: any) => (a.order ?? a.id) - (b.order ?? b.id))
-    .map((p: any) => ({
-      key: p.id,
-      label: p.name,
-      href: p.path,
-      Icon: p.icon && iconMap[p.icon] ? iconMap[p.icon] : FileText,
-    }));
+  const sidebarItems: SidebarItem[] = sortedAdminPages.map((p: any) => ({
+    id: p.id,
+    nombre: p.name ?? p.nombre ?? 'Sin título',
+    url: p.path ?? p.url ?? '#',
+    icon: p.icon ?? undefined,
+    order: p.order ?? undefined,
+    activo: (p.activo ?? p.active ?? true) as boolean,
+  }));
 
   const getPageTitle = () => {
     if (userRole === 'supervisor') return 'Supervisión';
-    return routes.find((r: any) => pathname.startsWith(r.href))?.label || 'Dashboard';
+    const current = sortedAdminPages.find((page: any) => pathname.startsWith(page.path));
+    return current?.name ?? current?.nombre ?? 'Dashboard';
   };
 
   const handleLogout = async (e: React.MouseEvent) => {
@@ -162,126 +121,35 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
     </div>
   );
 
-  const header = (
-    <Header actions={headerActions} showMenuButton={userRole !== 'supervisor'}>
-      <div className="flex w-full items-center gap-3">
-        <div className="hidden items-center gap-2 md:flex">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-6 w-6 text-primary"
-          >
-            <path d="M12 22a7 7 0 0 0 7-7c0-2-1-4-3-5s-3-2-3-5a7 7 0 0 0-14 0c0 3 1 4 3 5s3 3 3 5a7 7 0 0 0 7 7Z" />
-            <path d="M12 10.5A2.5 2.5 0 0 1 9.5 8" />
-          </svg>
-          <span className="font-headline text-lg">Génesis Sign</span>
-        </div>
-        <div className="flex flex-1 items-center">
-          <h1 className="truncate text-lg font-semibold md:text-xl">{getPageTitle()}</h1>
-        </div>
-      </div>
-    </Header>
-  );
-
   if (isLoading || !userRole) return null;
 
   return (
     <AuthGuard roles={['ADMIN', 'SUPERVISOR']}>
       {userRole === 'supervisor' ? (
         <div className="flex min-h-screen w-full flex-col bg-muted/40">
-          {header}
+          <TopBar title={getPageTitle()} actions={headerActions} showMenuButton={false} />
           <main className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-6">{children}</main>
         </div>
       ) : (
-        <AppLayout
-          header={header}
-          sidebar={
-            <AdminSidebar
-              routes={routes}
-              pathname={pathname}
-              isLoading={isLoading}
-              onNavigate={(href) => router.push(href)}
-            />
-          }
+        <LayoutShell
+          sidebar={{
+            items: sidebarItems,
+            user: {
+              name: displayName ?? me?.nombre ?? undefined,
+              email: email ?? me?.correo ?? undefined,
+              avatarUrl: (avatarUrl as string | undefined) ?? (me?.avatarUrl as string | undefined) ?? undefined,
+            },
+            isLoading,
+          }}
+          topBar={{
+            title: getPageTitle(),
+            actions: headerActions,
+            showMenuButton: true,
+          }}
         >
           <div className="flex flex-1 flex-col gap-4 p-4 md:gap-8 md:p-6">{children}</div>
-        </AppLayout>
+        </LayoutShell>
       )}
     </AuthGuard>
-  );
-}
-
-function AdminSidebar({ routes, pathname, isLoading, onNavigate }: AdminSidebarProps) {
-  const { closeSidebar } = useSidebarSheet();
-
-  const handleNavigate = React.useCallback(
-    (href: string) => {
-      onNavigate(href);
-      closeSidebar();
-    },
-    [onNavigate, closeSidebar]
-  );
-
-  return (
-    <Sidebar>
-      <SidebarHeader>
-        <div className="flex items-center gap-2">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="h-6 w-6 text-primary"
-          >
-            <path d="M12 22a7 7 0 0 0 7-7c0-2-1-4-3-5s-3-2-3-5a7 7 0 0 0-14 0c0 3 1 4 3 5s3 3 3 5a7 7 0 0 0 7 7Z" />
-            <path d="M12 10.5A2.5 2.5 0 0 1 9.5 8" />
-          </svg>
-          <span className="font-headline text-lg">Génesis Sign</span>
-        </div>
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarMenu>
-          {isLoading && routes.length === 0
-            ? Array.from({ length: 5 }).map((_, index) => (
-                <SidebarMenuSkeleton key={index} showIcon />
-              ))
-            : routes.map((item) => (
-                <SidebarMenuItem key={item.key}>
-                  <SidebarMenuButton
-                    onClick={() => handleNavigate(item.href)}
-                    isActive={pathname.startsWith(item.href)}
-                    icon={item.Icon}
-                  >
-                    {item.label}
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-        </SidebarMenu>
-      </SidebarContent>
-      <SidebarFooter className="hidden justify-end md:flex">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon"
-          className="h-8 w-8"
-          onClick={() => closeSidebar()}
-        >
-          <PanelLeft className="h-5 w-5" />
-          <span className="sr-only">Cerrar navegación</span>
-        </Button>
-      </SidebarFooter>
-    </Sidebar>
   );
 }

--- a/src/components/layout/AppLogo.tsx
+++ b/src/components/layout/AppLogo.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Image from "next/image";
+import { cn } from "@/lib/utils";
+
+interface AppLogoProps {
+  className?: string;
+}
+
+export function AppLogo({ className }: AppLogoProps) {
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <Image
+        src="/brand/logo-mark.svg"
+        alt="Génesis Sign"
+        width={28}
+        height={28}
+        priority
+        className="md:hidden"
+      />
+      <Image
+        src="/brand/logo-full.svg"
+        alt="Génesis Sign"
+        width={160}
+        height={40}
+        priority
+        className="hidden md:block"
+      />
+    </div>
+  );
+}

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
+import * as Lucide from "lucide-react";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { initials } from "@/lib/avatar";
+import { cn } from "@/lib/utils";
+
+export interface SidebarItem {
+  id: string | number;
+  nombre: string;
+  url: string;
+  icon?: string | null;
+  order?: number | null;
+  activo?: boolean | null;
+  active?: boolean | null;
+}
+
+export interface AppSidebarUser {
+  name?: string | null;
+  email?: string | null;
+  avatarUrl?: string | null;
+}
+
+export interface AppSidebarProps {
+  items: SidebarItem[];
+  user?: AppSidebarUser;
+  isLoading?: boolean;
+  isMobile?: boolean;
+  onNavigate?: () => void;
+}
+
+export function LucideIcon({
+  name,
+  className,
+}: {
+  name?: string | null;
+  className?: string;
+}) {
+  const Icon = (name && (Lucide as Record<string, React.ComponentType<any>>)[name]) || Lucide.Square;
+  return <Icon className={className} aria-hidden="true" />;
+}
+
+export function AppSidebar({ items, user, isLoading = false, isMobile = false, onNavigate }: AppSidebarProps) {
+  const pathname = usePathname();
+  const [isCollapsed, setIsCollapsed] = React.useState(false);
+
+  React.useEffect(() => {
+    if (isMobile) {
+      setIsCollapsed(false);
+      return;
+    }
+    const stored = typeof window !== "undefined" ? window.localStorage.getItem("sidebar:collapsed") : null;
+    if (stored === "1") {
+      setIsCollapsed(true);
+    }
+  }, [isMobile]);
+
+  const handleToggle = () => {
+    if (isMobile) return;
+    setIsCollapsed((prev) => {
+      const next = !prev;
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem("sidebar:collapsed", next ? "1" : "0");
+      }
+      return next;
+    });
+  };
+
+  const visibleItems = React.useMemo(() => {
+    return items
+      .filter((item) => (item.activo ?? item.active ?? true))
+      .sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
+  }, [items]);
+
+  const renderItem = (item: SidebarItem) => {
+    const href = item.url || "/";
+    const current = pathname === href || pathname?.startsWith(`${href}/`);
+    const content = (
+      <Link
+        href={href}
+        className={cn(
+          "group flex items-center gap-3 rounded-xl px-3 py-2 text-sm transition-colors hover:bg-accent/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background aria-[current=page]:bg-accent aria-[current=page]:text-accent-foreground",
+          isCollapsed && !isMobile && "justify-center px-2"
+        )}
+        aria-current={current ? "page" : undefined}
+        aria-label={isCollapsed && !isMobile ? item.nombre : undefined}
+        onClick={() => {
+          onNavigate?.();
+        }}
+      >
+        <LucideIcon name={item.icon ?? undefined} className="size-5" />
+        {isCollapsed && !isMobile ? <span className="sr-only">{item.nombre}</span> : <span className="truncate">{item.nombre}</span>}
+      </Link>
+    );
+
+    if (isCollapsed && !isMobile) {
+      return (
+        <Tooltip key={item.id} delayDuration={150}>
+          <TooltipTrigger asChild>{content}</TooltipTrigger>
+          <TooltipContent side="right" align="center">
+            {item.nombre}
+          </TooltipContent>
+        </Tooltip>
+      );
+    }
+
+    return (
+      <React.Fragment key={item.id}>{content}</React.Fragment>
+    );
+  };
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <div
+        className={cn(
+          "flex h-[100dvh] flex-col gap-4 border-r border-border/60 bg-card/70 p-3 text-sm shadow-sm backdrop-blur supports-[backdrop-filter]:bg-card/60",
+          isMobile ? "w-full rounded-none" : "rounded-r-2xl transition-[width] duration-300 ease-in-out",
+          isCollapsed && !isMobile ? "w-[80px]" : "w-[260px]"
+        )}
+      >
+        <div className="flex-1 overflow-y-auto">
+          <nav aria-label="Navegación principal" className="flex flex-col gap-1">
+            {isLoading ? (
+              <div className="flex flex-col gap-1">
+                {Array.from({ length: 5 }).map((_, index) => (
+                  <div
+                    key={`skeleton-${index}`}
+                    className={cn(
+                      "flex items-center gap-3 rounded-xl px-3 py-2",
+                      isCollapsed && !isMobile && "justify-center px-2"
+                    )}
+                  >
+                    <Skeleton className="size-5 rounded-md" />
+                    {!(isCollapsed && !isMobile) ? <Skeleton className="h-4 flex-1" /> : null}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              visibleItems.map((item) => renderItem(item))
+            )}
+          </nav>
+        </div>
+        <div className="space-y-3 border-t border-border/60 pt-3">
+          <div
+            className={cn(
+              "flex items-center gap-3 rounded-xl border border-border/60 bg-background/80 px-3 py-3 text-sm shadow-sm",
+              isCollapsed && !isMobile ? "justify-center" : "justify-between"
+            )}
+          >
+            <div className="flex items-center gap-3">
+              <Avatar className="size-9">
+                <AvatarImage src={user?.avatarUrl ?? undefined} alt={user?.name ?? "Usuario"} />
+                <AvatarFallback>{initials(user?.name ?? user?.email ?? "")}</AvatarFallback>
+              </Avatar>
+              {!(isCollapsed && !isMobile) ? (
+                <div className="flex min-w-0 flex-col">
+                  <span className="truncate font-medium leading-tight">{user?.name ?? "Usuario"}</span>
+                  {user?.email ? (
+                    <span className="truncate text-xs text-muted-foreground">{user.email}</span>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+            {!isMobile ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="icon"
+                    className="size-9"
+                    onClick={handleToggle}
+                  >
+                    {isCollapsed ? <ChevronsRight className="size-5" /> : <ChevronsLeft className="size-5" />}
+                    <span className="sr-only">
+                      {isCollapsed ? "Expandir menú" : "Colapsar menú"}
+                    </span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" align="center">
+                  {isCollapsed ? "Expandir" : "Colapsar"}
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/components/layout/LayoutShell.tsx
+++ b/src/components/layout/LayoutShell.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import * as React from "react";
+
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { cn } from "@/lib/utils";
+
+import { AppSidebar, type AppSidebarProps } from "./AppSidebar";
+import { TopBar, type TopBarProps } from "./TopBar";
+
+interface SidebarSheetContextValue {
+  isOpen: boolean;
+  openSidebar: () => void;
+  closeSidebar: () => void;
+  toggleSidebar: () => void;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const SidebarSheetContext = React.createContext<SidebarSheetContextValue | null>(null);
+
+export function useSidebarSheet() {
+  const context = React.useContext(SidebarSheetContext);
+
+  if (!context) {
+    throw new Error("useSidebarSheet must be used within a LayoutShell");
+  }
+
+  return context;
+}
+
+export function useOptionalSidebarSheet() {
+  return React.useContext(SidebarSheetContext);
+}
+
+interface LayoutShellProps {
+  sidebar: AppSidebarProps;
+  topBar: TopBarProps;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function LayoutShell({ sidebar, topBar, children, className }: LayoutShellProps) {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        setIsOpen(false);
+      }
+    };
+
+    if (mediaQuery.matches) {
+      setIsOpen(false);
+    }
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => mediaQuery.removeEventListener("change", handleChange);
+  }, []);
+
+  const contextValue = React.useMemo<SidebarSheetContextValue>(() => ({
+    isOpen,
+    setOpen: setIsOpen,
+    openSidebar: () => setIsOpen(true),
+    closeSidebar: () => setIsOpen(false),
+    toggleSidebar: () => setIsOpen((prev) => !prev),
+  }), [isOpen]);
+
+  const handleNavigate = React.useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <SidebarSheetContext.Provider value={contextValue}>
+      <Sheet open={isOpen} onOpenChange={setIsOpen}>
+        <SheetContent side="left" className="w-[18rem] p-0 md:hidden">
+          <div className="flex h-full flex-col overflow-y-auto">
+            <AppSidebar {...sidebar} isMobile onNavigate={handleNavigate} />
+          </div>
+        </SheetContent>
+      </Sheet>
+      <div className={cn("relative flex min-h-[100dvh] bg-muted/40", className)}>
+        <div className="sticky top-0 hidden h-[100dvh] shrink-0 md:flex">
+          <AppSidebar {...sidebar} onNavigate={handleNavigate} />
+        </div>
+        <div className="flex min-h-[100dvh] flex-1 flex-col bg-background">
+          <TopBar {...topBar} />
+          <main className="min-h-[100dvh] overflow-x-hidden">{children}</main>
+        </div>
+      </div>
+    </SidebarSheetContext.Provider>
+  );
+}

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import * as React from "react";
+import { Menu } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+import { AppLogo } from "./AppLogo";
+import { useOptionalSidebarSheet } from "./LayoutShell";
+
+export interface TopBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  title?: string;
+  actions?: React.ReactNode;
+  showMenuButton?: boolean;
+}
+
+export function TopBar({
+  className,
+  title,
+  actions,
+  showMenuButton = true,
+  ...props
+}: TopBarProps) {
+  const sheet = useOptionalSidebarSheet();
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-30 flex h-14 items-center gap-4 border-b border-border/80 bg-background/80 px-4 backdrop-blur supports-[backdrop-filter]:bg-background/60 md:h-16 md:px-6",
+        className
+      )}
+      {...props}
+    >
+      {showMenuButton ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="md:hidden"
+          onClick={() => sheet?.openSidebar()}
+        >
+          <Menu className="h-5 w-5" />
+          <span className="sr-only">Abrir menú de navegación</span>
+        </Button>
+      ) : (
+        <div className="hidden h-10 w-10 shrink-0 md:hidden" aria-hidden="true" />
+      )}
+      <AppLogo className="shrink-0" />
+      {title ? (
+        <div className="flex min-w-0 flex-1 items-center">
+          <h1 className="truncate text-base font-semibold text-foreground md:text-lg">
+            {title}
+          </h1>
+        </div>
+      ) : (
+        <div className="flex flex-1" />
+      )}
+      {actions ? <div className="flex items-center gap-2">{actions}</div> : null}
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- replace duplicated branding with a shared AppLogo/TopBar that reuse the login artwork
- add a responsive LayoutShell and collapsible AppSidebar that renders Lucide icons from backend data
- update the admin layout to use the new shell and brand assets for a polished UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65761d37483328a9107a20b28ed55