### PR TITLE
feat: update sidebar brand with Genesis Sign logo

### DIFF
--- a/src/components/brand/BrandLogo.tsx
+++ b/src/components/brand/BrandLogo.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+
+import { cn } from "@/lib/utils";
+
+type BrandLogoProps = {
+  href?: string;
+  className?: string;
+  imageClassName?: string;
+};
+
+export function BrandLogo({
+  href = "/admin/mis-documentos",
+  className,
+  imageClassName,
+}: BrandLogoProps) {
+  return (
+    <Link
+      href={href}
+      className={cn("flex items-center gap-2 px-3 py-4", className)}
+      aria-label="Ir a Mis Documentos"
+    >
+      <Image
+        src="/genesissign.png"
+        alt="Génesis Sign Logotipo"
+        width={144}
+        height={32}
+        priority
+        className={cn(
+          "h-8 w-auto max-w-full rounded-md select-none md:h-9",
+          imageClassName
+        )}
+      />
+    </Link>
+  );
+}

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -9,6 +9,7 @@ import * as Lucide from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { BrandLogo } from "@/components/brand/BrandLogo";
 import {
   Tooltip,
   TooltipContent,
@@ -132,6 +133,20 @@ export function AppSidebar({ items, user, isLoading = false, isMobile = false, o
         )}
       >
         <div className="flex-1 overflow-y-auto">
+          <div className="sticky top-0 z-10 bg-background/70 backdrop-blur supports-[backdrop-filter]:bg-background/60">
+            <div className={cn(isMobile ? "px-2 pt-2" : undefined)}>
+              <BrandLogo
+                className={cn(
+                  isMobile ? "px-2 py-3" : undefined,
+                  isCollapsed && !isMobile ? "justify-center px-0" : undefined
+                )}
+                imageClassName={cn(
+                  isCollapsed && !isMobile ? "h-8 w-full object-contain" : undefined
+                )}
+              />
+            </div>
+            <div className="h-px w-full bg-border" />
+          </div>
           <nav aria-label="Navegación principal" className="flex flex-col gap-1">
             {isLoading ? (
               <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary
- add a reusable BrandLogo component that links to /admin/mis-documentos and renders the Genesis Sign image
- integrate the brand logo into the desktop and mobile sidebar headers while preserving existing menu behavior

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d65e623a0c8332a213281066a9c5e2