### PR TITLE
feat: allow parallel signing in document detail

### DIFF
--- a/src/components/sign-dialog.tsx
+++ b/src/components/sign-dialog.tsx
@@ -152,13 +152,17 @@ export function SignDialog({
       toast({ title: 'Firma registrada' });
       return true;
     } catch (e: any) {
-      if (e?.status === 403) {
+      const status = e?.status ?? e?.response?.status;
+      const serverMessage =
+        e?.response?.data?.message ?? e?.response?.data?.error ?? e?.message;
+
+      if (status === 403) {
         toast({
           variant: 'destructive',
           title: 'No autorizado',
           description: 'Su sesión no coincide con el usuario que intenta firmar.',
         });
-      } else if (e?.status === 400) {
+      } else if (status === 400 && !serverMessage) {
         toast({
           variant: 'destructive',
           title: 'Error',
@@ -168,7 +172,7 @@ export function SignDialog({
         toast({
           variant: 'destructive',
           title: 'Error',
-          description: 'No se pudo firmar. Intenta de nuevo.',
+          description: serverMessage ?? 'No se pudo firmar. Intenta de nuevo.',
         });
       }
       return false;


### PR DESCRIPTION
## Summary
- allow assigned users to sign without waiting for earlier responsibilities on the document detail view
- show a neutral status message and keep the reject button enabled whenever the user can act
- surface backend error messages when signing fails in the signature dialog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d663da9a0083328cb835c8b89ded09