### PR TITLE
fix: replace Radix icon with Lucide equivalent in sign dialog

### DIFF
--- a/src/components/sign-dialog.tsx
+++ b/src/components/sign-dialog.tsx
@@ -24,7 +24,7 @@ import { Badge } from '@/components/ui/badge';
 import { initials } from '@/lib/avatar';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Checkbox } from '@/components/ui/checkbox';
-import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
+import { AlertTriangle as ExclamationTriangleIcon } from 'lucide-react';
 
 export type SignDialogProps = {
   open: boolean;


### PR DESCRIPTION
## Summary
- replace the Radix ExclamationTriangle icon import with the Lucide AlertTriangle alias in the sign dialog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6695f352083329363a737b10922fa