### PR TITLE
Improve document detail layout and AI summary UX

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
+import { AppFooter } from "@/components/layout/AppFooter";
 
 import { Providers } from "./providers";
 
@@ -33,12 +34,7 @@ export default function RootLayout({
         <Providers>
           <>
             <main className="flex-grow">{children}</main>
-            <footer className="py-4 px-6 text-center text-muted-foreground text-sm">
-              <div className="copyright">
-                ©2025 Génesis Sign • by MAC Génesis •{" "}
-                <span id="blockchain-status">⛓️</span>
-              </div>
-            </footer>
+            <AppFooter />
             <Toaster />
           </>
         </Providers>

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+export function AppFooter() {
+  const pathname = usePathname();
+  const hideFooter = pathname?.startsWith("/documento/");
+
+  if (hideFooter) {
+    return null;
+  }
+
+  return (
+    <footer className="py-4 px-6 text-center text-sm text-muted-foreground">
+      <div className="copyright">
+        ©2025 Génesis Sign • by MAC Génesis • <span id="blockchain-status">⛓️</span>
+      </div>
+    </footer>
+  );
+}
+
+export default AppFooter;


### PR DESCRIPTION
## Summary
- Create a route-aware footer component so the global footer stays hidden on `/documento/[id]`
- Reorder the document tabs to default to “Documento original”, keep query deep linking, and surface the AI summary CTA above the viewer on all form factors
- Replace the signer action buttons with a confirmation banner when the user already signed and simplify the AI summary modal layout without the PDF preview

## Testing
- npm run lint

## Captures
![Documento desktop](browser:/invocations/nlgmujnt/artifacts/artifacts/documento-desktop.png)
![Documento mobile](browser:/invocations/nlgmujnt/artifacts/artifacts/documento-mobile.png)

------
https://chatgpt.com/codex/tasks/task_e_68d82893989883329c1fe9df1532dd7a