### PR TITLE
Improve PDF viewer sizing and summary dialog scroll behavior

### DIFF
--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -242,10 +242,10 @@ export default function DocumentDetailPage() {
               className="h-[calc(100dvh-var(--app-header-h)-theme(spacing.10))] min-h-0 overflow-auto overscroll-y-contain pb-[calc(env(safe-area-inset-bottom)+88px)] md:pb-0"
             >
               <div className="flex min-h-full flex-col gap-3">
-                <div className="sticky top-2 z-30 md:static">
+                <div className="sticky top-2 z-20 mb-3 md:static md:mb-4">
                   <Button
                     onClick={handleSummarize}
-                    className="w-full justify-center gap-2"
+                    className="w-full md:w-auto justify-center gap-2 text-base md:text-sm rounded-2xl shadow-sm"
                     aria-label="Abrir resumen asistido por IA"
                   >
                     <Wand2 className="h-4 w-4" aria-hidden="true" />
@@ -320,15 +320,15 @@ export default function DocumentDetailPage() {
             </div>
             <div className="md:static sticky bottom-0 z-20 mt-4 border-t bg-background/80 px-3 py-3 backdrop-blur supports-[backdrop-filter]:bg-background/60">
               {alreadySigned ? (
-                <div className="flex h-12 items-center justify-center rounded-md border bg-muted px-3 text-center text-sm font-medium text-muted-foreground md:text-base">
+                <div className="flex h-14 items-center justify-center rounded-xl border bg-muted/40 px-3 text-center text-sm font-medium text-muted-foreground md:h-12 md:text-base">
                   Ud ya ha firmado este documento
                 </div>
               ) : (
                 <>
-                  <div className="flex gap-2">
+                  <div className="flex flex-col gap-2 md:flex-row">
                     <Button
                       onClick={handleSign}
-                      className="flex-1"
+                      className="w-full h-14 rounded-2xl md:h-12 md:rounded-xl"
                       disabled={!canSign}
                       title={actionTitle}
                     >
@@ -337,7 +337,7 @@ export default function DocumentDetailPage() {
                     <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
                       <Button
                         variant="destructive"
-                        className="flex-1"
+                        className="w-full h-14 rounded-2xl md:h-12 md:rounded-xl"
                         onClick={() => setRejectOpen(true)}
                         disabled={!canReject}
                         title={actionTitle}

--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -14,7 +14,6 @@ import { Loader2, Copy, Download, Play, Pause, Square } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { CuadroFirmaDetalle } from '@/services/documentsService';
 
@@ -424,18 +423,21 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
 
     return (
       <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-        <DialogContent aria-describedby="summary-pdf-desc" className="p-0">
-          <DialogHeader className="px-6 pt-6">
-            <DialogTitle>Resumen del documento</DialogTitle>
-            <DialogDescription id="summary-pdf-desc" className="sr-only">
-              Herramientas para generar y gestionar el resumen asistido por IA del documento.
-            </DialogDescription>
-          </DialogHeader>
+        <DialogContent
+          aria-describedby="summary-pdf-desc"
+          className="sm:max-w-[900px] max-h-[90vh] overflow-hidden p-0"
+        >
+          <div className="flex h-full flex-col">
+            <DialogHeader className="px-6 pt-6 pb-4">
+              <DialogTitle>Resumen del documento</DialogTitle>
+              <DialogDescription id="summary-pdf-desc" className="sr-only">
+                Herramientas para generar y gestionar el resumen asistido por IA del documento.
+              </DialogDescription>
+            </DialogHeader>
 
-          {/* Body del modal */}
-          <div className="px-6 pb-6">
-            <div className="flex flex-col gap-4">
-              <div className="flex flex-wrap items-center justify-end gap-2">
+            {/* Body del modal */}
+            <div className="flex flex-1 flex-col gap-4 px-4 pb-6">
+              <div className="flex flex-wrap items-center justify-end gap-2 px-2 md:px-4">
                 <Button onClick={generateSummary} disabled={isLoading}>
                   {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                   {isLoading ? 'Generando…' : 'Generar'}
@@ -533,14 +535,14 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                   </Tooltip>
                 )}
               </div>
-              <ScrollArea
-                className="max-h-[min(70vh,calc(100dvh-16rem))] min-h-[16rem] rounded-md border bg-background/90 p-4 text-sm"
+              <div
+                className="overflow-y-auto max-h-[70vh] px-2 md:px-4"
                 role="document"
                 aria-live="polite"
               >
                 {markdown.trim() ? (
-                  <div className="space-y-3 text-justify leading-relaxed">
-                    <ReactMarkdown className="prose prose-sm max-w-none text-foreground dark:prose-invert [&_*]:text-justify [&_*]:leading-relaxed">
+                  <div className="space-y-3 text-justify leading-relaxed text-sm">
+                    <ReactMarkdown className="prose prose-sm max-w-none text-foreground text-justify leading-relaxed dark:prose-invert [&_*]:text-justify [&_*]:leading-relaxed">
                       {markdown}
                     </ReactMarkdown>
                   </div>
@@ -551,8 +553,8 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                 ) : (
                   <p className="text-sm text-muted-foreground">Genera el resumen para visualizarlo aquí.</p>
                 )}
-              </ScrollArea>
-              {error && <p className="text-sm text-destructive">{error}</p>}
+              </div>
+              {error && <p className="px-2 text-sm text-destructive md:px-4">{error}</p>}
             </div>
           </div>
         </DialogContent>

--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -136,12 +136,22 @@ export function DocumentTabs({
         </TabsList>
       </div>
 
-      <TabsContent value="original" className="mt-0 h-full overflow-hidden data-[state=inactive]:hidden">
-        <SmartPDFViewer srcPdf={urlDocumento ?? null} className="h-full" />
+      <TabsContent value="original" className="mt-0 flex-1 data-[state=inactive]:hidden">
+        <div className="w-full min-h-[60vh] md:min-h-[70vh] overflow-hidden rounded-lg border bg-background">
+          <SmartPDFViewer
+            srcPdf={urlDocumento ?? null}
+            className="h-full w-full overflow-auto"
+          />
+        </div>
       </TabsContent>
 
-      <TabsContent value="firmas" className="mt-0 h-full overflow-hidden data-[state=inactive]:hidden">
-        <SmartPDFViewer srcPdf={urlCuadroFirmasPDF ?? null} className="h-full" />
+      <TabsContent value="firmas" className="mt-0 flex-1 data-[state=inactive]:hidden">
+        <div className="w-full min-h-[60vh] md:min-h-[70vh] overflow-hidden rounded-lg border bg-background">
+          <SmartPDFViewer
+            srcPdf={urlCuadroFirmasPDF ?? null}
+            className="h-full w-full overflow-auto"
+          />
+        </div>
       </TabsContent>
     </Tabs>
   );


### PR DESCRIPTION
## Summary
- increase the minimum height of PDF tabs so the viewer fills the viewport and remains scrollable
- refactor the document summary dialog layout to allow the content body to scroll while keeping controls fixed
- polish CTA and action button styles for better spacing and ergonomics on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d82e7bb80883329197aa4d574199a9