### PR TITLE
Adjust PDF viewer layout and summary modal actions

### DIFF
--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -239,7 +239,7 @@ export default function DocumentDetailPage() {
         <div className="mt-4 grid grid-cols-12 gap-4">
           <div className="col-span-12 md:col-span-8 xl:col-span-9">
             <div
-              className="h-[calc(100dvh-var(--app-header-h)-theme(spacing.10))] min-h-0 overflow-auto overscroll-y-contain pb-[calc(env(safe-area-inset-bottom)+88px)] md:pb-0"
+              className="h-[calc(100dvh-var(--app-header-h)-theme(spacing.10))] min-h-0 pb-[calc(env(safe-area-inset-bottom)+88px)] md:pb-0"
             >
               <div className="flex min-h-full flex-col gap-3">
                 <div className="sticky top-2 z-20 mb-3 md:static md:mb-4">

--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -437,22 +437,38 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
 
             {/* Body del modal */}
             <div className="flex flex-1 flex-col gap-4 px-4 pb-6">
-              <div className="flex flex-wrap items-center justify-end gap-2 px-2 md:px-4">
-                <Button onClick={generateSummary} disabled={isLoading}>
-                  {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  {isLoading ? 'Generando…' : 'Generar'}
-                </Button>
-                <Button variant="outline" onClick={copyToClipboard} disabled={!markdown.trim()}>
-                  <Copy className="mr-2 h-4 w-4" /> Copiar
-                </Button>
-                <Button variant="outline" onClick={downloadMarkdown} disabled={!markdown.trim()}>
-                  <Download className="mr-2 h-4 w-4" /> Descargar .md
-                </Button>
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-end px-2 md:px-4">
+                <div className="grid w-full grid-cols-2 gap-2 md:flex md:w-auto">
+                  <Button
+                    onClick={generateSummary}
+                    disabled={isLoading}
+                    className="col-span-2 h-11 w-full md:h-9 md:w-auto"
+                  >
+                    {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                    {isLoading ? 'Generando…' : 'Generar'}
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={copyToClipboard}
+                    disabled={!markdown.trim()}
+                    className="h-11 w-full md:h-9 md:w-auto"
+                  >
+                    <Copy className="mr-2 h-4 w-4" /> Copiar
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={downloadMarkdown}
+                    disabled={!markdown.trim()}
+                    className="h-11 w-full md:h-9 md:w-auto"
+                  >
+                    <Download className="mr-2 h-4 w-4" /> Descargar .md
+                  </Button>
+                </div>
                 {isSpeechSupported ? (
-                  <div className="flex items-center gap-2">
-                    {voices.length > 1 && (
+                  <div className="flex w-full flex-wrap items-center justify-between gap-2 md:w-auto md:justify-end">
+                    {voices.length > 0 && (
                       <select
-                        className="h-9 rounded-md border bg-background px-2 text-sm"
+                        className="h-11 w-full rounded-md border bg-background px-2 text-sm md:h-9 md:w-auto"
                         value={selectedVoice ? selectedVoice.voiceURI || selectedVoice.name : ''}
                         onChange={(event) => handleVoiceChange(event.target.value)}
                         aria-label="Seleccionar voz para lectura"
@@ -470,6 +486,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                     <Button
                       variant="outline"
                       size="icon"
+                      className="h-11 w-11 md:h-9 md:w-9"
                       onClick={handlePlay}
                       aria-label="Reproducir lectura en voz alta"
                       disabled={!markdown.trim() || !selectedVoice || speechStatus !== 'idle'}
@@ -480,6 +497,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                       <Button
                         variant="outline"
                         size="icon"
+                        className="h-11 w-11 md:h-9 md:w-9"
                         onClick={handlePause}
                         aria-label="Pausar lectura en voz alta"
                         disabled={speechStatus !== 'playing'}
@@ -491,6 +509,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                       <Button
                         variant="outline"
                         size="icon"
+                        className="h-11 w-11 md:h-9 md:w-9"
                         onClick={handleResume}
                         aria-label="Reanudar lectura en voz alta"
                         disabled={speechStatus !== 'paused'}
@@ -501,6 +520,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                     <Button
                       variant="outline"
                       size="icon"
+                      className="h-11 w-11 md:h-9 md:w-9"
                       onClick={handleStop}
                       aria-label="Detener lectura en voz alta"
                       disabled={speechStatus === 'idle'}
@@ -511,22 +531,22 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                 ) : (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div className="flex cursor-not-allowed items-center gap-2">
+                      <div className="flex w-full flex-wrap items-center justify-between gap-2 md:w-auto md:justify-end">
                         <select
-                          className="h-9 rounded-md border bg-background px-2 text-sm"
+                          className="h-11 w-full rounded-md border bg-background px-2 text-sm md:h-9 md:w-auto"
                           value=""
                           disabled
                           aria-label="Seleccionar voz para lectura"
                         >
                           <option>Sin voces disponibles</option>
                         </select>
-                        <Button variant="outline" size="icon" disabled>
+                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-9 md:w-9" disabled>
                           <Play className="h-4 w-4" />
                         </Button>
-                        <Button variant="outline" size="icon" disabled>
+                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-9 md:w-9" disabled>
                           <Pause className="h-4 w-4" />
                         </Button>
-                        <Button variant="outline" size="icon" disabled>
+                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-9 md:w-9" disabled>
                           <Square className="h-4 w-4" />
                         </Button>
                       </div>

--- a/src/components/document/DocumentTabs.tsx
+++ b/src/components/document/DocumentTabs.tsx
@@ -136,21 +136,19 @@ export function DocumentTabs({
         </TabsList>
       </div>
 
-      <TabsContent value="original" className="mt-0 flex-1 data-[state=inactive]:hidden">
-        <div className="w-full min-h-[60vh] md:min-h-[70vh] overflow-hidden rounded-lg border bg-background">
-          <SmartPDFViewer
-            srcPdf={urlDocumento ?? null}
-            className="h-full w-full overflow-auto"
-          />
+      <TabsContent value="original" className="mt-0 data-[state=inactive]:hidden">
+        <div className="w-full overflow-hidden rounded-lg border bg-background">
+          <div className="h-[75vh] md:h-[82vh]">
+            <SmartPDFViewer srcPdf={urlDocumento ?? null} className="h-full w-full" />
+          </div>
         </div>
       </TabsContent>
 
-      <TabsContent value="firmas" className="mt-0 flex-1 data-[state=inactive]:hidden">
-        <div className="w-full min-h-[60vh] md:min-h-[70vh] overflow-hidden rounded-lg border bg-background">
-          <SmartPDFViewer
-            srcPdf={urlCuadroFirmasPDF ?? null}
-            className="h-full w-full overflow-auto"
-          />
+      <TabsContent value="firmas" className="mt-0 data-[state=inactive]:hidden">
+        <div className="w-full overflow-hidden rounded-lg border bg-background">
+          <div className="h-[75vh] md:h-[82vh]">
+            <SmartPDFViewer srcPdf={urlCuadroFirmasPDF ?? null} className="h-full w-full" />
+          </div>
         </div>
       </TabsContent>
     </Tabs>


### PR DESCRIPTION
## Summary
- remove outer scroll from the document tab container so only the PDF viewer scrolls
- expand both document and signature PDF viewers to 75–82vh while keeping their rounded border wrappers
- reorganize the document summary dialog actions for a mobile-first layout while preserving the scrolling body

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d832fc0d488332b425fc2c96d4a383