### PR TITLE
Adjust DocumentSummaryDialog action layout

### DIFF
--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -437,12 +437,12 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
 
             {/* Body del modal */}
             <div className="flex flex-1 flex-col gap-4 px-4 pb-6">
-              <div className="flex flex-col gap-2 md:flex-row md:flex-nowrap md:items-center md:justify-end whitespace-nowrap px-2 md:px-4">
-                <div className="grid w-full grid-cols-2 gap-2 md:flex md:w-auto">
+              <div className="flex flex-col gap-2 px-2 md:px-6 md:flex-row md:flex-nowrap md:items-center md:justify-between whitespace-nowrap">
+                <div className="grid w-full grid-cols-2 gap-2 md:inline-flex md:w-auto md:flex-none">
                   <Button
                     onClick={generateSummary}
                     disabled={isLoading}
-                    className="col-span-2 h-11 w-full md:h-9 md:w-auto"
+                    className="col-span-2 h-11 w-full md:h-10 md:w-auto"
                   >
                     {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                     {isLoading ? 'Generando…' : 'Generar'}
@@ -451,7 +451,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                     variant="outline"
                     onClick={copyToClipboard}
                     disabled={!markdown.trim()}
-                    className="h-11 w-full md:h-9 md:w-auto"
+                    className="h-11 w-full md:h-10 md:w-auto"
                   >
                     <Copy className="mr-2 h-4 w-4" /> Copiar
                   </Button>
@@ -459,16 +459,16 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                     variant="outline"
                     onClick={downloadMarkdown}
                     disabled={!markdown.trim()}
-                    className="h-11 w-full md:h-9 md:w-auto"
+                    className="h-11 w-full md:h-10 md:w-auto"
                   >
                     <Download className="mr-2 h-4 w-4" /> Descargar .md
                   </Button>
                 </div>
                 {isSpeechSupported ? (
-                  <div className="flex w-full flex-wrap items-center justify-between gap-2 md:w-auto md:justify-end">
+                  <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:flex-nowrap md:justify-end md:pl-4">
                     {voices.length > 0 && (
                       <select
-                        className="h-11 w-full rounded-md border bg-background px-2 text-sm md:h-9 md:w-56"
+                        className="h-11 w-full rounded-md border bg-background px-2 text-sm md:h-10 md:w-56"
                         value={selectedVoice ? selectedVoice.voiceURI || selectedVoice.name : ''}
                         onChange={(event) => handleVoiceChange(event.target.value)}
                         aria-label="Seleccionar voz para lectura"
@@ -486,7 +486,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                     <Button
                       variant="outline"
                       size="icon"
-                      className="h-11 w-11 md:h-9 md:w-9"
+                      className="h-11 w-11 md:h-10 md:w-10"
                       onClick={handlePlay}
                       aria-label="Reproducir lectura en voz alta"
                       disabled={!markdown.trim() || !selectedVoice || speechStatus !== 'idle'}
@@ -497,7 +497,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                       <Button
                         variant="outline"
                         size="icon"
-                        className="h-11 w-11 md:h-9 md:w-9"
+                        className="h-11 w-11 md:h-10 md:w-10"
                         onClick={handlePause}
                         aria-label="Pausar lectura en voz alta"
                         disabled={speechStatus !== 'playing'}
@@ -509,7 +509,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                       <Button
                         variant="outline"
                         size="icon"
-                        className="h-11 w-11 md:h-9 md:w-9"
+                        className="h-11 w-11 md:h-10 md:w-10"
                         onClick={handleResume}
                         aria-label="Reanudar lectura en voz alta"
                         disabled={speechStatus !== 'paused'}
@@ -520,7 +520,7 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                     <Button
                       variant="outline"
                       size="icon"
-                      className="h-11 w-11 md:h-9 md:w-9"
+                      className="h-11 w-11 md:h-10 md:w-10"
                       onClick={handleStop}
                       aria-label="Detener lectura en voz alta"
                       disabled={speechStatus === 'idle'}
@@ -531,22 +531,22 @@ export const DocumentSummaryDialog = forwardRef<DocumentSummaryDialogHandle, Doc
                 ) : (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div className="flex w-full flex-wrap items-center justify-between gap-2 md:w-auto md:justify-end">
+                      <div className="flex w-full flex-wrap items-center gap-2 md:w-auto md:flex-nowrap md:justify-end md:pl-4">
                         <select
-                          className="h-11 w-full rounded-md border bg-background px-2 text-sm md:h-9 md:w-56"
+                          className="h-11 w-full rounded-md border bg-background px-2 text-sm md:h-10 md:w-56"
                           value=""
                           disabled
                           aria-label="Seleccionar voz para lectura"
                         >
                           <option>Sin voces disponibles</option>
                         </select>
-                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-9 md:w-9" disabled>
+                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-10 md:w-10" disabled>
                           <Play className="h-4 w-4" />
                         </Button>
-                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-9 md:w-9" disabled>
+                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-10 md:w-10" disabled>
                           <Pause className="h-4 w-4" />
                         </Button>
-                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-9 md:w-9" disabled>
+                        <Button variant="outline" size="icon" className="h-11 w-11 md:h-10 md:w-10" disabled>
                           <Square className="h-4 w-4" />
                         </Button>
                       </div>


### PR DESCRIPTION
## Summary
- align the action row padding with the dialog header and space desktop groups evenly
- prevent the primary action group from stretching on desktop layouts
- normalize control heights and adjust the TTS group spacing for consistent desktop appearance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83cfa2498833291347c27ccc38c8f