### PR TITLE
Fix assignment edit responsibility mapping

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,4 +4,9 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   { ignores: ['.next/**', 'dist/**'] },
   js.configs.recommended,
+  {
+    rules: {
+      'no-undef': 'error',
+    },
+  },
 );

--- a/src/components/assignments/AssignmentForm.tsx
+++ b/src/components/assignments/AssignmentForm.tsx
@@ -65,7 +65,12 @@ export type AssignmentFormInitialValues = {
   pdfUrl?: string | null;
   pdfName?: string | null;
   observaciones?: string | null;
-  responsables?: { id: number; nombre: string; responsabilidad: Responsibility }[];
+  responsables?: {
+    id: number;
+    nombre: string;
+    responsabilidad: Responsibility | null;
+    responsabilidadId: number | null;
+  }[];
   elaboraUserId?: number | null;
 };
 


### PR DESCRIPTION
## Summary
- build a resilient `mapResponsables` helper that keeps every signer and preserves responsibility ids when editing assignments
- allow assignment form initial values to carry nullable responsibilities so the UI can show unassigned signers
- enable the eslint `no-undef` rule to avoid undefined variable regressions

## Testing
- npm run lint *(fails: environment cannot resolve `@eslint/js`)*
- npm run typecheck *(fails: environment cannot download `@types/formidable`)*

------
https://chatgpt.com/codex/tasks/task_e_68db96229d588332af1ac1a64c7a61d0