### PR TITLE
feat: add signature column and compact filters

### DIFF
--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -1,0 +1,21 @@
+export function getMySignInfo(item: any, currentUserId: number) {
+  const normalizedUserId = Number(currentUserId);
+  if (!Number.isFinite(normalizedUserId)) {
+    return { assigned: false, signed: false, lastSignedAt: null };
+  }
+  const entries = Array.isArray(item?.signatureEntries)
+    ? item.signatureEntries
+    : item?.cuadro_firma?.cuadro_firma_user ?? [];
+  const mine = entries.filter(
+    (e: any) => Number(e?.user_id ?? e?.userId) === normalizedUserId,
+  );
+  const assigned = mine.length > 0;
+  const signed = mine.some((e: any) => e?.estaFirmado === true);
+  const lastSignedAt = signed
+    ? mine
+        .filter((e: any) => e?.estaFirmado === true && e?.fecha_firma)
+        .map((e: any) => new Date(e.fecha_firma).getTime())
+        .sort((a: number, b: number) => b - a)[0]
+    : null;
+  return { assigned, signed, lastSignedAt };
+}


### PR DESCRIPTION
## Summary
- add a reusable helper to derive the signed state for the logged-in user
- show the new "Mi firma" chip in the documents table and cards, replacing the description column
- redesign the filters with a compact status dropdown/select, updated "Mi firma" segmented control, and refreshed empty state copy

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3642b23083329c9b0be6030abf36