### PR TITLE
Add idUser to cuadro firma update payload

### DIFF
--- a/src/app/admin/asignaciones/[id]/page.tsx
+++ b/src/app/admin/asignaciones/[id]/page.tsx
@@ -303,6 +303,8 @@ export default function AssignmentEditPage() {
     async (data: AssignmentFormSubmitData) => {
       if (!documentId) return;
 
+      const currentUserId = toNumber(me?.id);
+
       const payload: Record<string, unknown> = {
         titulo: data.title,
         descripcion: data.description,
@@ -310,6 +312,7 @@ export default function AssignmentEditPage() {
         codigo: data.code,
         empresa_id: data.empresaId ?? null,
         responsables: data.responsables,
+        idUser: currentUserId ?? me?.id ?? null,
       };
 
       try {
@@ -335,9 +338,23 @@ export default function AssignmentEditPage() {
         router.push(`/documento/${documentId}`);
       } catch (error: any) {
         console.error("Error updating assignment", error);
-        const message =
+        const status = error?.response?.status;
+        const rawMessage =
           error?.response?.data?.message || error?.message || "No se pudo actualizar la asignación.";
-        toast({ variant: "destructive", title: "Error", description: String(message) });
+        const message = String(rawMessage);
+        if (
+          status === 500 &&
+          typeof rawMessage === "string" &&
+          rawMessage.toLowerCase().includes("cuadro_firma_estado_historial.create")
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Error",
+            description: "No se pudo registrar historial; intenta de nuevo o contacta soporte",
+          });
+          return;
+        }
+        toast({ variant: "destructive", title: "Error", description: message });
       }
     },
     [documentId, me?.id, queryClient, router, toast],

--- a/src/components/assignments/AssignmentForm.tsx
+++ b/src/components/assignments/AssignmentForm.tsx
@@ -561,13 +561,63 @@ export function AssignmentForm({
         enteradoUsers,
       });
 
+      const pickText = (candidates: unknown[]) => {
+        for (const candidate of candidates) {
+          if (typeof candidate === "string") {
+            const trimmed = candidate.trim();
+            if (trimmed) {
+              return trimmed;
+            }
+          }
+        }
+        return "N/D";
+      };
+
+      const normalizeResponsable = <T extends { puesto: string; gerencia: string }>(
+        responsable: T | undefined,
+        user?: any,
+      ): T | undefined => {
+        if (!responsable) return responsable;
+
+        const puesto = pickText([
+          responsable.puesto,
+          user?.posicionNombre,
+          user?.posicion?.nombre,
+        ]);
+
+        const gerencia = pickText([
+          responsable.gerencia,
+          user?.gerenciaNombre,
+          user?.gerencia?.nombre,
+        ]);
+
+        return {
+          ...responsable,
+          puesto,
+          gerencia,
+        };
+      };
+
+      const responsablesWithFallback = {
+        elabora: normalizeResponsable(responsables.elabora, elaboraUserData ?? undefined),
+        revisa: responsables.revisa.map((responsable, index) =>
+          normalizeResponsable(responsable, revisaUsers[index])!,
+        ),
+        aprueba: responsables.aprueba.map((responsable, index) =>
+          normalizeResponsable(responsable, apruebaUsers[index])!,
+        ),
+        enterado: responsables.enterado.map((responsable, index) =>
+          normalizeResponsable(responsable, enteradoUsers[index])!,
+        ),
+      };
+
       await onSubmit({
         title: trimmedTitle,
         description: trimmedDescription,
         version: finalVersion,
         code: trimmedCode,
         empresaId: currentEmpresaId,
-        responsables,
+        responsables: responsablesWithFallback,
         pdfFile,
         observaciones: trimmedObservaciones,
         hasFileChange,

--- a/src/services/documentsService.ts
+++ b/src/services/documentsService.ts
@@ -234,7 +234,30 @@ export async function createCuadroFirma(body: FormData) {
 }
 
 export async function updateCuadroFirma(id: number, payload: Record<string, any>) {
-  const { data } = await api.patch(`/documents/cuadro-firmas/${id}`, payload);
+  const body: Record<string, any> = { ...payload };
+
+  if (body.idUser == null) {
+    try {
+      const { data: me } = await api.get<{ id?: number | string }>(
+        '/users/me',
+      );
+      const rawId = me?.id;
+      if (typeof rawId === 'number' && Number.isFinite(rawId)) {
+        body.idUser = rawId;
+      } else if (typeof rawId === 'string' && rawId.trim() !== '') {
+        const parsed = Number(rawId);
+        if (Number.isFinite(parsed)) {
+          body.idUser = parsed;
+        } else {
+          body.idUser = rawId;
+        }
+      }
+    } catch (error) {
+      console.error('Error fetching current user for updateCuadroFirma', error);
+    }
+  }
+
+  const { data } = await api.patch(`/documents/cuadro-firmas/${id}`, body);
   return unwrapOne<any>(data);
 }
 


### PR DESCRIPTION
## Summary
- include the current user id in cuadro de firmas updates both in the service layer and assignment edit payloads
- ensure responsable puesto and gerencia fields always have values when submitting edits
- surface a dedicated toast when historial creation fails during assignment updates

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68dc5d3cf69083329ac45d5a6300b44f