### PR TITLE
Add signature modal workflow to assignment pages

### DIFF
--- a/src/app/admin/asignaciones/page.tsx
+++ b/src/app/admin/asignaciones/page.tsx
@@ -1,43 +1,29 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 import AssignmentForm, {
   type AssignmentFormSubmitData,
 } from "@/components/assignments/AssignmentForm";
 import { useToast } from "@/hooks/use-toast";
-import { createCuadroFirma } from "@/services/documentsService";
 import { getEmpresas } from "@/services/empresasService";
-import api from "@/lib/axiosConfig";
 import { useSession } from "@/lib/session";
-
-const extractItems = (payload: any): any[] => {
-  if (!payload || typeof payload !== "object") return [];
-  if (Array.isArray(payload.items)) return payload.items;
-  const data = payload.data ?? payload.result ?? payload.body;
-  if (data && Array.isArray(data.items)) return data.items;
-  if (data && Array.isArray(data.documentos)) return data.documentos;
-  if (Array.isArray(payload.data)) return payload.data;
-  return [];
-};
-
-const pickId = (items: any[], currentUserId?: number): number | undefined => {
-  if (!Array.isArray(items) || items.length === 0) return undefined;
-  const mine = Number.isFinite(currentUserId)
-    ? items.find((item) => Number(item?.usuarioCreacion?.id) === currentUserId)
-    : undefined;
-  const candidate = mine ?? items[0];
-  const rawId = candidate?.id;
-  const numericId = typeof rawId === "number" ? rawId : Number(rawId);
-  return Number.isFinite(numericId) ? (numericId as number) : undefined;
-};
+import { SignDocumentModal } from "@/components/sign/SignDocumentModal";
+import { useSignAndPersist } from "@/hooks/useSignAndPersist";
+import type { SignSource } from "@/types/signatures";
 
 export default function AsignacionesPage() {
-  const router = useRouter();
   const { toast } = useToast();
-  const { me } = useSession();
+  const { signatureUrl } = useSession();
+  const { createThenSign } = useSignAndPersist();
   const [companies, setCompanies] = useState<Array<{ id: number; nombre: string }>>([]);
   const [companiesLoading, setCompaniesLoading] = useState(false);
+  const [signModalOpen, setSignModalOpen] = useState(false);
+  const [modalLoading, setModalLoading] = useState(false);
+  const [pendingValues, setPendingValues] = useState<AssignmentFormSubmitData | null>(null);
+  const pendingPromiseRef = useRef<{
+    resolve: () => void;
+    reject: (error: unknown) => void;
+  } | null>(null);
 
   useEffect(() => {
     let active = true;
@@ -68,112 +54,48 @@ export default function AsignacionesPage() {
     };
   }, [toast]);
 
+  const clearPendingState = useCallback(() => {
+    setSignModalOpen(false);
+    setPendingValues(null);
+    pendingPromiseRef.current = null;
+  }, []);
+
   const handleSubmit = useCallback(
-    async (data: AssignmentFormSubmitData) => {
-      if (!data.pdfFile) {
-        toast({
-          variant: "destructive",
-          title: "Falta el archivo PDF",
-          description: "Cargue un PDF para continuar.",
-        });
-        return;
-      }
+    async (data: AssignmentFormSubmitData) =>
+      new Promise<void>((resolve, reject) => {
+        pendingPromiseRef.current = { resolve, reject };
+        setPendingValues(data);
+        setSignModalOpen(true);
+      }),
+    [],
+  );
 
-      const formData = new FormData();
-      formData.append("file", data.pdfFile);
-      formData.append("responsables", JSON.stringify(data.responsables));
-
-      const meta = {
-        titulo: data.title,
-        descripcion: data.description,
-        version: data.version,
-        codigo: data.code,
-        empresa_id: data.empresaId ?? 1,
-        createdBy: me?.id,
-      } as Record<string, unknown>;
-
-      if (data.observaciones) {
-        meta.observaciones = data.observaciones;
-      }
-
-      Object.entries(meta).forEach(([key, value]) => {
-        if (value != null && value !== "") {
-          formData.append(key, String(value));
-        }
-      });
-
+  const handleModalConfirm = useCallback(
+    async (signSource: SignSource) => {
+      if (!pendingValues) return;
+      const pending = pendingPromiseRef.current;
+      setModalLoading(true);
       try {
-        await createCuadroFirma(formData);
-
-        let nextId: number | undefined;
-        const currentUserId = Number(me?.id);
-
-        const fetchLatestId = async (limit: number): Promise<number | undefined> => {
-          const { data } = await api.get(
-            "/documents/cuadro-firmas/documentos/supervision",
-            { params: { page: 1, limit, sort: "desc" } },
-          );
-          return pickId(extractItems(data), currentUserId);
-        };
-
-        try {
-          nextId = await fetchLatestId(1);
-          if (!nextId) {
-            nextId = await fetchLatestId(5);
-          }
-        } catch (lookupError) {
-          console.error("Document lookup error:", lookupError);
-        }
-
-        if (typeof nextId === "number") {
-          router.replace(`/documento/${nextId}`);
-          return;
-        }
-
-        toast({
-          title: "Documento enviado",
-          description: "No se pudo obtener el ID automáticamente. Revisa la lista de supervisión.",
-        });
-      } catch (error: any) {
-        const status = error?.response?.status;
-        let message = error?.response?.data?.message || error?.message || "";
-        if (Array.isArray(message)) message = message.join(" | ");
-        const m = String(message).toLowerCase();
-
-        console.error("Document creation error:", error);
-
-        if (status === 409 || m.includes("código") || m.includes("codigo") || m.includes("conflictexception")) {
-          toast({
-            variant: "destructive",
-            title: "Código en uso",
-            description: "Ya existe un documento con ese código. Cambia el código y vuelve a intentar.",
-          });
-          return;
-        }
-
-        if (
-          status === 500 ||
-          m.includes("server has closed the connection") ||
-          m.includes("prisma") ||
-          m.includes("base de datos")
-        ) {
-          toast({
-            variant: "destructive",
-            title: "Conexión a BD inestable",
-            description: "Vuelve a intentar en unos segundos.",
-          });
-          return;
-        }
-
-        toast({
-          variant: "destructive",
-          title: "Error de creación",
-          description: message || "Hubo un problema al crear el documento.",
-        });
+        await createThenSign({ formValues: pendingValues, signSource });
+        pending?.resolve();
+      } catch (error) {
+        pending?.reject(error);
+      } finally {
+        setModalLoading(false);
+        clearPendingState();
       }
     },
-    [me?.id, router, toast],
+    [clearPendingState, createThenSign, pendingValues],
   );
+
+  const handleModalClose = useCallback(() => {
+    if (modalLoading) return;
+    const pending = pendingPromiseRef.current;
+    if (pending) {
+      pending.reject(new Error("signature-modal-cancelled"));
+    }
+    clearPendingState();
+  }, [clearPendingState, modalLoading]);
 
   return (
     <div className="container mx-auto h-full -mt-8">
@@ -182,6 +104,13 @@ export default function AsignacionesPage() {
         onSubmit={handleSubmit}
         companies={companies}
         companiesLoading={companiesLoading}
+      />
+      <SignDocumentModal
+        open={signModalOpen}
+        onClose={handleModalClose}
+        onConfirm={handleModalConfirm}
+        loading={modalLoading}
+        currentSignatureUrl={signatureUrl ?? undefined}
       />
     </div>
   );

--- a/src/components/sign/SignDocumentModal.tsx
+++ b/src/components/sign/SignDocumentModal.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ChangeEvent } from "react";
+import type SignatureCanvas from "react-signature-canvas";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
+import { SignaturePad } from "@/components/signature-pad";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Upload, Loader2, PenLine, Image as ImageIcon, X } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { SignSource } from "@/types/signatures";
+
+const MAX_UPLOAD_SIZE = 2 * 1024 * 1024; // 2MB
+
+type Mode = SignSource["mode"];
+
+type StoredSignatureProps = {
+  signatureUrl?: string | null;
+};
+
+const StoredSignaturePreview = ({ signatureUrl }: StoredSignatureProps) => {
+  if (!signatureUrl) {
+    return (
+      <div className="flex h-48 w-full flex-col items-center justify-center rounded-lg border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center">
+        <p className="text-sm text-muted-foreground">
+          No tienes una firma guardada. Puedes dibujarla o subir una imagen para continuar.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-48 w-full items-center justify-center rounded-lg border bg-background p-4">
+      <img
+        src={signatureUrl}
+        alt="Firma guardada"
+        className="h-full max-h-40 w-full object-contain"
+      />
+    </div>
+  );
+};
+
+type SignDocumentModalProps = {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (payload: SignSource) => void | Promise<void>;
+  loading?: boolean;
+  currentSignatureUrl?: string | null;
+};
+
+export function SignDocumentModal({
+  open,
+  onClose,
+  onConfirm,
+  loading,
+  currentSignatureUrl,
+}: SignDocumentModalProps) {
+  const { toast } = useToast();
+  const signatureCanvasRef = useRef<SignatureCanvas>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [mode, setMode] = useState<Mode>("stored");
+  const [hasDrawn, setHasDrawn] = useState(false);
+  const [uploadedFile, setUploadedFile] = useState<File | null>(null);
+  const [uploadedPreview, setUploadedPreview] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setMode("stored");
+      setHasDrawn(false);
+      setUploadedFile(null);
+      setUploadedPreview(null);
+      if (signatureCanvasRef.current) {
+        signatureCanvasRef.current.clear();
+      }
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (uploadedPreview) {
+        URL.revokeObjectURL(uploadedPreview);
+      }
+    };
+  }, [uploadedPreview]);
+
+  const hasStoredSignature = useMemo(() => Boolean(currentSignatureUrl), [currentSignatureUrl]);
+
+  const handleDrawEnd = useCallback(() => {
+    if (!signatureCanvasRef.current) return;
+    setHasDrawn(!signatureCanvasRef.current.isEmpty());
+  }, []);
+
+  const handleClearDraw = useCallback(() => {
+    if (!signatureCanvasRef.current) return;
+    signatureCanvasRef.current.clear();
+    setHasDrawn(false);
+  }, []);
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0] ?? null;
+      if (!file) {
+        setUploadedFile(null);
+        setUploadedPreview(null);
+        return;
+      }
+
+      if (!/image\/png|image\/jpe?g/i.test(file.type)) {
+        toast({
+          variant: "destructive",
+          title: "Formato no permitido",
+          description: "Solo se admiten archivos PNG o JPG.",
+        });
+        event.target.value = "";
+        return;
+      }
+
+      if (file.size > MAX_UPLOAD_SIZE) {
+        toast({
+          variant: "destructive",
+          title: "Archivo demasiado grande",
+          description: "La firma debe pesar 2MB o menos.",
+        });
+        event.target.value = "";
+        return;
+      }
+
+      setUploadedFile(file);
+      if (uploadedPreview) {
+        URL.revokeObjectURL(uploadedPreview);
+      }
+      setUploadedPreview(URL.createObjectURL(file));
+    },
+    [toast, uploadedPreview],
+  );
+
+  const canConfirm = useMemo(() => {
+    if (mode === "stored") return hasStoredSignature;
+    if (mode === "draw") return hasDrawn;
+    if (mode === "upload") return Boolean(uploadedFile);
+    return false;
+  }, [mode, hasStoredSignature, hasDrawn, uploadedFile]);
+
+  const handleCancel = useCallback(() => {
+    if (loading) return;
+    onClose();
+  }, [loading, onClose]);
+
+  const handleConfirm = useCallback(async () => {
+    if (loading) return;
+
+    if (mode === "stored") {
+      if (!hasStoredSignature) {
+        toast({
+          variant: "destructive",
+          title: "Firma no disponible",
+          description: "No tienes una firma guardada. Selecciona otra opción.",
+        });
+        return;
+      }
+      await onConfirm({ mode: "stored" });
+      return;
+    }
+
+    if (mode === "draw") {
+      const canvas = signatureCanvasRef.current;
+      if (!canvas || canvas.isEmpty()) {
+        toast({
+          variant: "destructive",
+          title: "Lienzo vacío",
+          description: "Dibuja tu firma antes de continuar.",
+        });
+        return;
+      }
+      const dataUrl = canvas.toDataURL("image/png");
+      await onConfirm({ mode: "draw", dataUrl });
+      return;
+    }
+
+    if (mode === "upload") {
+      if (!uploadedFile) {
+        toast({
+          variant: "destructive",
+          title: "Archivo requerido",
+          description: "Selecciona una imagen de tu firma.",
+        });
+        return;
+      }
+      await onConfirm({ mode: "upload", file: uploadedFile });
+    }
+  }, [hasStoredSignature, loading, mode, onConfirm, toast, uploadedFile]);
+
+  return (
+    <Dialog open={open} onOpenChange={(value) => (!value ? onClose() : null)}>
+      <DialogContent className="max-w-3xl" aria-describedby="sign-document-modal-desc">
+        <DialogHeader>
+          <DialogTitle>Firmar documento</DialogTitle>
+          <DialogDescription id="sign-document-modal-desc">
+            Elige cómo deseas aplicar tu firma como <span className="font-semibold">Elabora</span> antes de guardar los cambios.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs
+          value={mode}
+          onValueChange={(value) => setMode(value as Mode)}
+          className="mt-4"
+        >
+          <TabsList className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+            <TabsTrigger value="stored" className="flex items-center gap-2">
+              <ImageIcon className="h-4 w-4" /> Firma actual
+            </TabsTrigger>
+            <TabsTrigger value="draw" className="flex items-center gap-2">
+              <PenLine className="h-4 w-4" /> Dibujar
+            </TabsTrigger>
+            <TabsTrigger value="upload" className="flex items-center gap-2">
+              <Upload className="h-4 w-4" /> Subir imagen
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="stored" className="mt-4">
+            <StoredSignaturePreview signatureUrl={currentSignatureUrl} />
+          </TabsContent>
+
+          <TabsContent value="draw" className="mt-4 space-y-4">
+            <SignaturePad ref={signatureCanvasRef} onEnd={handleDrawEnd} />
+            <div className="flex flex-col gap-2 text-sm text-muted-foreground sm:flex-row sm:items-center sm:justify-between">
+              <p>Dibuja tu firma directamente con el cursor o con tu dedo en pantallas táctiles.</p>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleClearDraw}
+                className="gap-2 self-start sm:self-auto"
+              >
+                <X className="h-4 w-4" /> Limpiar
+              </Button>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="upload" className="mt-4 space-y-4">
+            <div className="flex flex-col gap-3">
+              <Input
+                ref={fileInputRef}
+                type="file"
+                accept="image/png,image/jpeg"
+                onChange={handleFileChange}
+              />
+              <p className="text-sm text-muted-foreground">
+                Acepta archivos PNG o JPG de hasta 2MB. La imagen se adaptará al espacio disponible.
+              </p>
+            </div>
+            {uploadedPreview ? (
+              <div className="flex h-48 w-full items-center justify-center rounded-lg border bg-background p-4">
+                <img
+                  src={uploadedPreview}
+                  alt="Vista previa de la firma"
+                  className="h-full max-h-40 w-full object-contain"
+                />
+              </div>
+            ) : (
+              <div className="flex h-48 w-full flex-col items-center justify-center rounded-lg border border-dashed border-muted-foreground/40 bg-muted/40 p-6 text-center">
+                <p className="text-sm text-muted-foreground">
+                  Selecciona una imagen para ver aquí una vista previa antes de firmar.
+                </p>
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
+
+        <Alert variant="warning" className="mt-6">
+          <AlertTitle>Importante</AlertTitle>
+          <AlertDescription>
+            Esta firma es <span className="font-semibold">irrevocable</span>. Asegúrate de haber leído el documento antes de confirmarla.
+          </AlertDescription>
+        </Alert>
+
+        <div className="mt-6 flex flex-col gap-2 sm:flex-row sm:justify-end">
+          <Button type="button" variant="outline" onClick={handleCancel} disabled={loading}>
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!canConfirm || loading}
+            className={cn("gap-2", loading && "cursor-not-allowed")}
+          >
+            {loading ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" /> Firmando…
+              </>
+            ) : (
+              "Firmar con mi firma"
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/signature-pad.tsx
+++ b/src/components/signature-pad.tsx
@@ -1,25 +1,33 @@
 
-"use client"
+"use client";
 
 import React, { forwardRef } from 'react';
 import SignatureCanvas from 'react-signature-canvas';
+import type { SignatureCanvasProps } from 'react-signature-canvas';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 
+export const SignaturePad = forwardRef<SignatureCanvas, SignatureCanvasProps>((props, ref) => {
+  const isMobile = useIsMobile();
+  const { canvasProps, penColor = 'black', ...rest } = props;
 
-export const SignaturePad = forwardRef<SignatureCanvas>((props, ref) => {
-    const isMobile = useIsMobile();
-    return (
-      <div className='w-full h-48 rounded-lg border bg-background'>
-        <SignatureCanvas
-            ref={ref}
-            penColor='black'
-            canvasProps={{ 
-                className: cn('w-full h-full rounded-lg', isMobile ? 'touch-auto' : 'touch-none')
-            }}
-        />
-      </div>
-    );
+  return (
+    <div className="h-48 w-full rounded-lg border bg-background">
+      <SignatureCanvas
+        ref={ref}
+        penColor={penColor}
+        {...rest}
+        canvasProps={{
+          ...canvasProps,
+          className: cn(
+            'w-full h-full rounded-lg',
+            isMobile ? 'touch-auto' : 'touch-none',
+            canvasProps?.className,
+          ),
+        }}
+      />
+    </div>
+  );
 });
 
 SignaturePad.displayName = 'SignaturePad';

--- a/src/hooks/useSignAndPersist.ts
+++ b/src/hooks/useSignAndPersist.ts
@@ -1,0 +1,373 @@
+"use client";
+
+import { useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useToast } from "@/hooks/use-toast";
+import { useSession } from "@/lib/session";
+import { useQueryClient } from "@tanstack/react-query";
+import api from "@/lib/axiosConfig";
+import type { AssignmentFormSubmitData } from "@/components/assignments/AssignmentForm";
+import {
+  createCuadroFirma,
+  signCuadroFirma,
+  updateCuadroFirma,
+  updateDocumentoAsignacion,
+} from "@/services/documentsService";
+import type { SignSource } from "@/types/signatures";
+
+const RESPONSABILIDAD_ELABORA_ID = 4;
+
+const extractItems = (payload: any): any[] => {
+  if (!payload || typeof payload !== "object") return [];
+  if (Array.isArray(payload.items)) return payload.items;
+  const data = payload.data ?? payload.result ?? payload.body;
+  if (data && Array.isArray(data.items)) return data.items;
+  if (data && Array.isArray(data.documentos)) return data.documentos;
+  if (Array.isArray(payload.data)) return payload.data;
+  return [];
+};
+
+const pickId = (items: any[], currentUserId?: number): number | undefined => {
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+  const mine = Number.isFinite(currentUserId)
+    ? items.find((item) => Number(item?.usuarioCreacion?.id) === currentUserId)
+    : undefined;
+  const candidate = mine ?? items[0];
+  const rawId = candidate?.id;
+  const numericId = typeof rawId === "number" ? rawId : Number(rawId);
+  return Number.isFinite(numericId) ? (numericId as number) : undefined;
+};
+
+const resolveCreatedId = (created: any): number | null => {
+  const candidates = [
+    created?.id,
+    created?.cuadroFirmaId,
+    created?.cuadro_firma?.id,
+    created?.cuadroFirma?.id,
+    created?.documento?.id,
+    created?.document?.id,
+  ];
+
+  for (const value of candidates) {
+    const numeric = typeof value === "number" ? value : Number(value);
+    if (Number.isFinite(numeric)) {
+      return numeric as number;
+    }
+  }
+
+  return null;
+};
+
+const normalizeMessage = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return value.join(" | ");
+  }
+  if (value == null) return "";
+  return String(value);
+};
+
+export type { SignSource };
+
+type CreateThenSignArgs = {
+  formValues: AssignmentFormSubmitData;
+  signSource: SignSource;
+};
+
+type UpdateThenMaybeSignArgs = {
+  id: number;
+  formValues: AssignmentFormSubmitData;
+  isElabora: boolean;
+  alreadySigned: boolean;
+  signSource?: SignSource;
+};
+
+export function useSignAndPersist() {
+  const { toast } = useToast();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const { me } = useSession();
+
+  const currentUserId = useMemo(() => {
+    const raw = me?.id;
+    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+    if (typeof raw === "string" && raw.trim() !== "") {
+      const parsed = Number(raw);
+      if (Number.isFinite(parsed)) return parsed;
+    }
+    return undefined;
+  }, [me?.id]);
+
+  const resolvedUserId = useMemo(() => {
+    const raw = me?.id;
+    if (typeof raw === "number" && Number.isFinite(raw)) return raw;
+    if (typeof raw === "string" && raw.trim() !== "") {
+      const parsed = Number(raw);
+      return Number.isFinite(parsed) ? parsed : raw;
+    }
+    return currentUserId ?? null;
+  }, [currentUserId, me?.id]);
+
+  const fetchCreatedId = useCallback(
+    async () => {
+      try {
+        const { data } = await api.get(
+          "/documents/cuadro-firmas/documentos/supervision",
+          { params: { page: 1, limit: 5, sort: "desc" } },
+        );
+        return pickId(extractItems(data), currentUserId);
+      } catch (error) {
+        console.error("Document lookup error:", error);
+        return undefined;
+      }
+    },
+    [currentUserId],
+  );
+
+  const createThenSign = useCallback(
+    async ({ formValues, signSource }: CreateThenSignArgs) => {
+      if (!formValues.pdfFile) {
+        throw new Error("PDF requerido");
+      }
+
+      const formData = new FormData();
+      formData.append("file", formValues.pdfFile);
+      formData.append("responsables", JSON.stringify(formValues.responsables));
+
+      const meta: Record<string, unknown> = {
+        titulo: formValues.title,
+        descripcion: formValues.description,
+        version: formValues.version,
+        codigo: formValues.code,
+        empresa_id: formValues.empresaId ?? 1,
+        createdBy: resolvedUserId ?? null,
+      };
+
+      if (formValues.observaciones) {
+        meta.observaciones = formValues.observaciones;
+      }
+
+      Object.entries(meta).forEach(([key, value]) => {
+        if (value != null && value !== "") {
+          formData.append(key, String(value));
+        }
+      });
+
+      let createdId: number | undefined;
+
+      try {
+        const created = await createCuadroFirma(formData);
+        createdId = resolveCreatedId(created) ?? undefined;
+        if (!createdId) {
+          createdId = await fetchCreatedId();
+        }
+      } catch (error: any) {
+        const status = error?.response?.status ?? error?.status;
+        let message = normalizeMessage(
+          error?.response?.data?.message ?? error?.message ?? "",
+        );
+        const lowercase = message.toLowerCase();
+
+        console.error("Document creation error:", error);
+
+        if (
+          status === 409 ||
+          lowercase.includes("código") ||
+          lowercase.includes("codigo") ||
+          lowercase.includes("conflictexception")
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Código en uso",
+            description:
+              "Ya existe un documento con ese código. Cambia el código y vuelve a intentar.",
+          });
+          throw error;
+        }
+
+        if (
+          status === 500 ||
+          lowercase.includes("server has closed the connection") ||
+          lowercase.includes("prisma") ||
+          lowercase.includes("base de datos")
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Conexión a BD inestable",
+            description: "Vuelve a intentar en unos segundos.",
+          });
+          throw error;
+        }
+
+        toast({
+          variant: "destructive",
+          title: "Error de creación",
+          description: message || "Hubo un problema al crear el documento.",
+        });
+        throw error;
+      }
+
+      if (!createdId) {
+        toast({
+          title: "Documento creado",
+          description:
+            "No se pudo obtener el ID automáticamente. Revisa la lista de supervisión.",
+        });
+        return;
+      }
+
+      let signError: any = null;
+
+      const userIdForSignature = resolvedUserId ?? currentUserId;
+
+      if (userIdForSignature == null) {
+        toast({
+          variant: "destructive",
+          title: "Usuario no identificado",
+          description:
+            "El documento se creó, pero no se pudo determinar el usuario para firmar automáticamente.",
+        });
+        router.push(`/documento/${createdId}?tab=cuadro`);
+        return;
+      }
+
+      try {
+        await signCuadroFirma({
+          cuadroFirmaId: createdId,
+          userId: userIdForSignature,
+          responsabilidadId: RESPONSABILIDAD_ELABORA_ID,
+          source: signSource,
+        });
+        toast({ title: "Creado y firmado" });
+      } catch (error: any) {
+        console.error("Auto-sign error", error);
+        signError = error;
+        const serverMessage = normalizeMessage(
+          error?.response?.data?.message ?? error?.message ?? "",
+        );
+        toast({
+          variant: "destructive",
+          title: "Firma pendiente",
+          description:
+            serverMessage ||
+            "No se pudo firmar automáticamente. Puedes completar la firma desde el detalle.",
+        });
+      } finally {
+        router.push(`/documento/${createdId}?tab=cuadro`);
+      }
+
+      if (signError) {
+        return;
+      }
+    },
+    [
+      currentUserId,
+      fetchCreatedId,
+      me?.id,
+      router,
+      toast,
+    ],
+  );
+
+  const updateThenMaybeSign = useCallback(
+    async ({ id, formValues, isElabora, alreadySigned, signSource }: UpdateThenMaybeSignArgs) => {
+      const payload: Record<string, unknown> = {
+        titulo: formValues.title,
+        descripcion: formValues.description,
+        version: formValues.version,
+        codigo: formValues.code,
+        empresa_id: formValues.empresaId ?? null,
+        responsables: formValues.responsables,
+        idUser: resolvedUserId ?? null,
+      };
+
+      try {
+        await updateCuadroFirma(id, payload);
+
+        if (formValues.hasFileChange && formValues.pdfFile) {
+          await updateDocumentoAsignacion(id, {
+            file: formValues.pdfFile,
+            idUser: resolvedUserId ?? undefined,
+            observaciones: formValues.observaciones,
+          });
+        }
+
+        if (isElabora && !alreadySigned && signSource) {
+          const userIdForSignature = resolvedUserId ?? currentUserId;
+
+          if (userIdForSignature == null) {
+            toast({
+              variant: "destructive",
+              title: "Usuario no identificado",
+              description:
+                "No se pudo determinar el usuario actual para firmar automáticamente.",
+            });
+          } else {
+            try {
+              await signCuadroFirma({
+                cuadroFirmaId: id,
+                userId: userIdForSignature,
+                responsabilidadId: RESPONSABILIDAD_ELABORA_ID,
+                source: signSource,
+              });
+              toast({ title: "Actualizado y firmado" });
+            } catch (error: any) {
+              console.error("Auto-sign update error", error);
+              const serverMessage = normalizeMessage(
+                error?.response?.data?.message ?? error?.message ?? "",
+              );
+              toast({
+                variant: "destructive",
+                title: "Firma pendiente",
+                description:
+                  serverMessage ||
+                  "El documento se actualizó pero la firma quedó pendiente. Puedes completarla desde el detalle.",
+              });
+            }
+          }
+        } else {
+          toast({
+            title: "Actualizado",
+            description: "La asignación se actualizó correctamente.",
+          });
+        }
+
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: ["documents"] }),
+          queryClient.invalidateQueries({ queryKey: ["documents", "supervision"] }),
+          queryClient.invalidateQueries({ queryKey: ["documents", "supervision", "stats"] }),
+          queryClient.invalidateQueries({ queryKey: ["documents", "me"] }),
+        ]);
+
+        router.push(`/documento/${id}?tab=cuadro`);
+      } catch (error: any) {
+        console.error("Error updating assignment", error);
+        const status = error?.response?.status ?? error?.status;
+        const rawMessage =
+          error?.response?.data?.message ||
+          error?.message ||
+          "No se pudo actualizar la asignación.";
+        const message = String(rawMessage);
+
+        if (
+          status === 500 &&
+          typeof rawMessage === "string" &&
+          rawMessage.toLowerCase().includes("cuadro_firma_estado_historial.create")
+        ) {
+          toast({
+            variant: "destructive",
+            title: "Error",
+            description:
+              "No se pudo registrar historial; intenta de nuevo o contacta soporte",
+          });
+          throw error;
+        }
+
+        toast({ variant: "destructive", title: "Error", description: message });
+        throw error;
+      }
+    },
+    [currentUserId, me?.id, queryClient, router, toast],
+  );
+
+  return { createThenSign, updateThenMaybeSign };
+}

--- a/src/types/signatures.ts
+++ b/src/types/signatures.ts
@@ -1,0 +1,4 @@
+export type SignSource =
+  | { mode: 'stored' }
+  | { mode: 'draw'; dataUrl: string }
+  | { mode: 'upload'; file: File };


### PR DESCRIPTION
## Summary
- add a reusable SignDocumentModal that exposes stored, draw, and upload signature sources
- create a useSignAndPersist hook to orchestrate create/update flows with automatic Elabora signing
- update assignment create/edit pages and document services to trigger the modal and sign with the selected source

## Testing
- npm run lint *(fails: missing @eslint/js package in eslint.config.mjs)*

------
https://chatgpt.com/codex/tasks/task_e_68dc66bac98c8332b8d73c3a84ba245f