### PR TITLE
feat: redesign document summary dialog with chat

### DIFF
--- a/src/app/documento/[id]/page.tsx
+++ b/src/app/documento/[id]/page.tsx
@@ -420,7 +420,6 @@ export default function DocumentDetailPage() {
           ref={summaryDialogRef}
           documentId={detalle.id}
           cuadroFirmasId={detalle.id}
-          docData={detalle}
         />
       )}
     </div>

--- a/src/components/ai/DocChatPanel.tsx
+++ b/src/components/ai/DocChatPanel.tsx
@@ -1,0 +1,317 @@
+"use client";
+
+import { Bot, Loader2, Send } from "lucide-react";
+import React, {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import ReactMarkdown from "react-markdown";
+
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { cn } from "@/lib/utils";
+import { sendDocChatMessage } from "@/services/documentsService";
+
+const MAX_INPUT_CHARS = 2000;
+
+type MessageRole = "user" | "assistant";
+
+type Message = {
+  id: string;
+  role: MessageRole;
+  content: string;
+  isStreaming?: boolean;
+};
+
+export interface DocChatPanelProps {
+  cuadroFirmasId: number;
+  sessionId: string | null;
+  onRequireSession: () => Promise<string>;
+}
+
+const isReadableStream = (
+  value: unknown,
+): value is ReadableStream<Uint8Array> => {
+  return (
+    typeof ReadableStream !== "undefined" &&
+    value instanceof ReadableStream &&
+    typeof value.getReader === "function"
+  );
+};
+
+export function DocChatPanel({
+  sessionId,
+  onRequireSession,
+}: DocChatPanelProps) {
+  const { toast } = useToast();
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState("");
+  const [isSending, setIsSending] = useState(false);
+  const abortRef = useRef<AbortController | null>(null);
+  const scrollAreaRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const scrollToBottom = useCallback(() => {
+    const viewport = scrollAreaRef.current?.querySelector(
+      "[data-radix-scroll-area-viewport]",
+    ) as HTMLDivElement | null;
+    if (viewport) {
+      viewport.scrollTo({ top: viewport.scrollHeight, behavior: "smooth" });
+    }
+  }, []);
+
+  const parseStreamChunk = useCallback((rawChunk: string) => {
+    return rawChunk
+      .split(/\n/)
+      .map((line) => line.replace(/^data:\s*/i, ""))
+      .filter((line) => line && line !== "[DONE]")
+      .join("\n");
+  }, []);
+
+  useEffect(() => {
+    scrollToBottom();
+  }, [messages, isSending, scrollToBottom]);
+
+  useEffect(() => {
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
+    setMessages([]);
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) {
+      void onRequireSession().catch(() => undefined);
+    }
+  }, [onRequireSession, sessionId]);
+
+  const ensureSession = useCallback(async () => {
+    if (sessionId) return sessionId;
+    return onRequireSession();
+  }, [onRequireSession, sessionId]);
+
+  const handleSend = useCallback(async () => {
+    const trimmed = input.trim();
+    if (!trimmed || isSending) {
+      return;
+    }
+
+    const idBase = Date.now().toString(36);
+    const userMessage: Message = {
+      id: `user-${idBase}`,
+      role: "user",
+      content: trimmed,
+    };
+    const assistantMessage: Message = {
+      id: `assistant-${idBase}`,
+      role: "assistant",
+      content: "",
+      isStreaming: true,
+    };
+
+    setMessages((prev) => [...prev, userMessage, assistantMessage]);
+    setInput("");
+    setIsSending(true);
+
+    if (textareaRef.current) {
+      textareaRef.current.focus();
+    }
+
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    try {
+      const sid = await ensureSession();
+      const response = await sendDocChatMessage(sid, trimmed, {
+        signal: controller.signal,
+        stream: true,
+      });
+
+      if (isReadableStream(response)) {
+        const reader = response.getReader();
+        const decoder = new TextDecoder();
+        let done = false;
+        while (!done) {
+          const { value, done: doneReading } = await reader.read();
+          done = doneReading;
+          if (value) {
+            const chunk = decoder.decode(value, { stream: !done });
+            const parsed = parseStreamChunk(chunk);
+            if (!parsed) {
+              continue;
+            }
+            setMessages((prev) =>
+              prev.map((message) =>
+                message.id === assistantMessage.id
+                  ? {
+                      ...message,
+                      content: `${message.content}${parsed}`,
+                    }
+                  : message,
+              ),
+            );
+          }
+        }
+      } else if (response && typeof (response as any).content === "string") {
+        const content = (response as { content: string }).content;
+        setMessages((prev) =>
+          prev.map((message) =>
+            message.id === assistantMessage.id
+              ? {
+                  ...message,
+                  content,
+                }
+              : message,
+          ),
+        );
+      } else {
+        throw new Error("Respuesta inesperada del servidor");
+      }
+    } catch (error: any) {
+      if (controller.signal.aborted) {
+        return;
+      }
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === assistantMessage.id
+            ? {
+                ...message,
+                content: "No se pudo obtener respuesta.",
+                isStreaming: false,
+              }
+            : message,
+        ),
+      );
+      toast({
+        variant: "destructive",
+        title: "Error en el chat",
+        description: error?.message || "Intenta nuevamente.",
+      });
+    } finally {
+      setMessages((prev) =>
+        prev.map((message) =>
+          message.id === assistantMessage.id
+            ? {
+                ...message,
+                isStreaming: false,
+              }
+            : message,
+        ),
+      );
+      setIsSending(false);
+      abortRef.current = null;
+    }
+  }, [ensureSession, input, isSending, parseStreamChunk, toast]);
+
+  const handleSubmit = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      void handleSend();
+    },
+    [handleSend],
+  );
+
+  const placeholder = useMemo(
+    () =>
+      "Haz preguntas sobre el documento. Usa Shift+Enter para salto de línea.",
+    [],
+  );
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex-1 overflow-hidden">
+        <ScrollArea ref={scrollAreaRef} className="h-full pr-4">
+          <div className="flex flex-col gap-4 p-4 text-sm">
+            {messages.length === 0 ? (
+              <p className="text-muted-foreground">
+                Inicia una conversación para consultar detalles del documento.
+              </p>
+            ) : (
+              messages.map((message) => (
+                <div
+                  key={message.id}
+                  className={cn(
+                    "flex gap-3", 
+                    message.role === "user" ? "justify-end" : "justify-start",
+                  )}
+                >
+                  {message.role === "assistant" && (
+                    <div className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-muted">
+                      <Bot className="h-4 w-4" />
+                    </div>
+                  )}
+                  <div
+                    className={cn(
+                      "max-w-full rounded-lg px-3 py-2", 
+                      message.role === "assistant"
+                        ? "bg-muted text-left"
+                        : "bg-primary text-primary-foreground",
+                    )}
+                  >
+                    {message.role === "assistant" ? (
+                      <ReactMarkdown className="prose prose-sm max-w-none dark:prose-invert">
+                        {message.content || (message.isStreaming ? "IA está escribiendo…" : "")}
+                      </ReactMarkdown>
+                    ) : (
+                      <p>{message.content}</p>
+                    )}
+                    {message.isStreaming && message.role === "assistant" && (
+                      <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        <span>IA está escribiendo…</span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </ScrollArea>
+      </div>
+      <form
+        onSubmit={handleSubmit}
+        className="space-y-3 border-t bg-background/95 p-4"
+      >
+        <Textarea
+          ref={textareaRef}
+          value={input}
+          onChange={(event) => {
+            const value = event.target.value;
+            setInput(value.length > MAX_INPUT_CHARS ? value.slice(0, MAX_INPUT_CHARS) : value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.shiftKey) {
+              event.preventDefault();
+              void handleSend();
+            }
+          }}
+          rows={3}
+          placeholder={placeholder}
+        />
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <span className="text-xs text-muted-foreground">
+            {input.length}/{MAX_INPUT_CHARS}
+          </span>
+          <Button type="submit" disabled={!input.trim() || isSending}>
+            {isSending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="mr-2 h-4 w-4" />
+            )}
+            {isSending ? "IA está escribiendo…" : "Enviar"}
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/ai/SummaryActions.tsx
+++ b/src/components/ai/SummaryActions.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Loader2, Copy, Download, Sparkles } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export interface SummaryActionsProps {
+  disabled: boolean;
+  isLoading: boolean;
+  onGenerate: () => void;
+  onCopy: () => void;
+  onDownload: () => void;
+  className?: string;
+}
+
+export function SummaryActions({
+  disabled,
+  isLoading,
+  onGenerate,
+  onCopy,
+  onDownload,
+  className,
+}: SummaryActionsProps) {
+  return (
+    <div className={cn("flex flex-wrap items-center gap-2", className)}>
+      <Button onClick={onGenerate} disabled={isLoading}>
+        {isLoading ? (
+          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        ) : (
+          <Sparkles className="mr-2 h-4 w-4" />
+        )}
+        {isLoading ? "Generando…" : "Generar Resumen IA"}
+      </Button>
+      <Button
+        variant="outline"
+        onClick={onCopy}
+        disabled={disabled || isLoading}
+        className="min-w-[110px]"
+      >
+        <Copy className="mr-2 h-4 w-4" />
+        Copiar
+      </Button>
+      <Button
+        variant="outline"
+        onClick={onDownload}
+        disabled={disabled || isLoading}
+        className="min-w-[130px]"
+      >
+        <Download className="mr-2 h-4 w-4" />
+        Descargar
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ai/SummaryTTSControls.tsx
+++ b/src/components/ai/SummaryTTSControls.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import {
+  Pause,
+  Play,
+  Square,
+  Volume2,
+} from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  forwardRef,
+} from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useToast } from "@/hooks/use-toast";
+import {
+  formatVoiceLabel,
+  loadPreferredVoice,
+  savePreferredVoice,
+  sortVoices,
+} from "@/utils/voiceLabels";
+
+export interface SummaryTTSControlsProps {
+  markdown: string;
+  className?: string;
+}
+
+export interface SummaryTTSControlsHandle {
+  stop: () => void;
+}
+
+type TTSStatus = "idle" | "playing" | "paused";
+
+const MAX_SEGMENT_CHARS = 200;
+
+function sanitizeMarkdown(markdown: string) {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/\*(.*?)\*/g, "$1")
+    .replace(/__(.*?)__/g, "$1")
+    .replace(/_(.*?)_/g, "$1")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[[^\]]+\]\([^)]*\)/g, "$1")
+    .replace(/>+/g, " ")
+    .replace(/#+\s*/g, "")
+    .replace(/[-*]\s+/g, "")
+    .replace(/\r/g, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .replace(/[ \t]{2,}/g, " ")
+    .trim();
+}
+
+function splitIntoSegments(text: string) {
+  if (!text) return [] as string[];
+  const rawParts = text
+    .split(/\n{2,}/)
+    .flatMap((paragraph) => paragraph.split(/(?<=\.)\s+/))
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const segments: string[] = [];
+
+  rawParts.forEach((part) => {
+    let remaining = part;
+    while (remaining.length > 0) {
+      if (remaining.length <= MAX_SEGMENT_CHARS) {
+        segments.push(remaining.trim());
+        break;
+      }
+      let sliceIndex = remaining.lastIndexOf(" ", MAX_SEGMENT_CHARS);
+      if (sliceIndex <= 0) {
+        sliceIndex = MAX_SEGMENT_CHARS;
+      }
+      const chunk = remaining.slice(0, sliceIndex).trim();
+      if (chunk) {
+        segments.push(chunk);
+      }
+      remaining = remaining.slice(sliceIndex).trim();
+    }
+  });
+
+  return segments;
+}
+
+const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSControlsProps>(
+  ({ markdown, className }, ref) => {
+    const { toast } = useToast();
+    const [status, setStatus] = useState<TTSStatus>("idle");
+    const [voices, setVoices] = useState<SpeechSynthesisVoice[]>([]);
+    const [selectedVoice, setSelectedVoice] = useState<SpeechSynthesisVoice | null>(null);
+    const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
+    const queueRef = useRef<string[]>([]);
+    const currentIndexRef = useRef(0);
+    const isClient = typeof window !== "undefined";
+    const isSupported = isClient && "speechSynthesis" in window;
+
+    const sanitizedMarkdown = useMemo(() => sanitizeMarkdown(markdown), [markdown]);
+
+    const stop = useCallback(() => {
+      if (!isSupported) return;
+      window.speechSynthesis.cancel();
+      utteranceRef.current = null;
+      queueRef.current = [];
+      currentIndexRef.current = 0;
+      setStatus("idle");
+    }, [isSupported]);
+
+    useImperativeHandle(ref, () => ({ stop }), [stop]);
+
+    useEffect(() => {
+      if (!isSupported) return;
+
+      const updateVoices = () => {
+        const available = sortVoices(window.speechSynthesis.getVoices());
+        setVoices(available);
+        setSelectedVoice((current) => {
+          if (current && available.some((voice) => voice.voiceURI === current.voiceURI)) {
+            return current;
+          }
+          const stored = loadPreferredVoice(available);
+          return stored ?? available[0] ?? null;
+        });
+      };
+
+      updateVoices();
+      window.speechSynthesis.addEventListener("voiceschanged", updateVoices);
+
+      return () => {
+        window.speechSynthesis.removeEventListener("voiceschanged", updateVoices);
+      };
+    }, [isSupported]);
+
+    useEffect(() => {
+      if (!selectedVoice) return;
+      savePreferredVoice(selectedVoice);
+    }, [selectedVoice]);
+
+    useEffect(() => {
+      return () => {
+        stop();
+      };
+    }, [stop]);
+
+    const speakNext = useCallback(() => {
+      if (!isSupported || !selectedVoice) return;
+      const segments = queueRef.current;
+      if (currentIndexRef.current >= segments.length) {
+        stop();
+        return;
+      }
+
+      const utterance = new SpeechSynthesisUtterance(segments[currentIndexRef.current]);
+      utterance.voice = selectedVoice;
+      utterance.onend = () => {
+        currentIndexRef.current += 1;
+        speakNext();
+      };
+      utterance.onerror = () => {
+        toast({
+          variant: "destructive",
+          title: "Error de voz",
+          description: "No se pudo reproducir el audio.",
+        });
+        stop();
+      };
+      utteranceRef.current = utterance;
+      window.speechSynthesis.speak(utterance);
+      setStatus("playing");
+    }, [isSupported, selectedVoice, stop, toast]);
+
+    const handlePlay = useCallback(() => {
+      if (!isSupported) {
+        toast({
+          variant: "destructive",
+          title: "TTS no disponible",
+          description: "El navegador no soporta lectura en voz.",
+        });
+        return;
+      }
+      if (!sanitizedMarkdown) {
+        toast({
+          title: "Sin contenido",
+          description: "Genera el resumen antes de reproducir.",
+        });
+        return;
+      }
+      if (!selectedVoice) {
+        toast({
+          title: "Selecciona una voz",
+          description: "Elige una voz para usar lectura en voz alta.",
+        });
+        return;
+      }
+
+      stop();
+      queueRef.current = splitIntoSegments(sanitizedMarkdown);
+      currentIndexRef.current = 0;
+      if (!queueRef.current.length) {
+        toast({
+          title: "Sin contenido",
+          description: "No hay texto disponible para leer.",
+        });
+        return;
+      }
+      speakNext();
+    }, [isSupported, sanitizedMarkdown, selectedVoice, speakNext, stop, toast]);
+
+    const handlePause = useCallback(() => {
+      if (!isSupported) return;
+      window.speechSynthesis.pause();
+      setStatus("paused");
+    }, [isSupported]);
+
+    const handleResume = useCallback(() => {
+      if (!isSupported) return;
+      window.speechSynthesis.resume();
+      setStatus("playing");
+    }, [isSupported]);
+
+    const handleStop = useCallback(() => {
+      stop();
+    }, [stop]);
+
+    const disablePlay = !sanitizedMarkdown || status !== "idle" || !selectedVoice;
+
+    return (
+      <div className={className}>
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-2">
+            <Volume2 className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+            <Select
+              value={selectedVoice?.voiceURI || selectedVoice?.name || ""}
+              onValueChange={(value) => {
+                const voice = voices.find(
+                  (v) => v.voiceURI === value || v.name === value,
+                );
+                setSelectedVoice(voice ?? null);
+                stop();
+              }}
+              disabled={!voices.length}
+            >
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Selecciona voz" />
+              </SelectTrigger>
+              <SelectContent>
+                {voices.map((voice) => {
+                  const id = voice.voiceURI || voice.name;
+                  return (
+                    <SelectItem key={id} value={voice.voiceURI || voice.name}>
+                      {formatVoiceLabel(voice)}
+                    </SelectItem>
+                  );
+                })}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handlePlay}
+              disabled={disablePlay}
+            >
+              <Play className="mr-1 h-4 w-4" />
+              Reproducir
+            </Button>
+            {status === "playing" ? (
+              <Button size="sm" variant="outline" onClick={handlePause}>
+                <Pause className="mr-1 h-4 w-4" />
+                Pausa
+              </Button>
+            ) : status === "paused" ? (
+              <Button size="sm" variant="outline" onClick={handleResume}>
+                <Play className="mr-1 h-4 w-4" />
+                Reanudar
+              </Button>
+            ) : null}
+            {(status === "playing" || status === "paused") && (
+              <Button size="sm" variant="outline" onClick={handleStop}>
+                <Square className="mr-1 h-4 w-4" />
+                Detener
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+
+SummaryTTSControls.displayName = "SummaryTTSControls";
+
+export { SummaryTTSControls };

--- a/src/services/documentsService.ts
+++ b/src/services/documentsService.ts
@@ -504,3 +504,49 @@ export async function signDocument(payload: {
   }
 }
 
+export const DOCUMENT_SUMMARY_ANALYZE_PATH = '/api/documents/analyze-pdf'; // TODO: ajustar path si el backend difiere
+const DOCUMENT_CHAT_BASE_PATH = '/api/v1/documents/ai/chat'; // TODO: ajustar path si el backend difiere
+
+export async function startDocChat(cuadroFirmasId: number, init: RequestInit = {}) {
+  const response = await fetch(`${DOCUMENT_CHAT_BASE_PATH}/start/${cuadroFirmasId}`, {
+    method: 'POST',
+    ...init,
+  });
+
+  if (!response.ok) {
+    throw new Error('No se pudo iniciar el chat del documento');
+  }
+
+  return (await response.json()) as { sessionId: string };
+}
+
+type SendDocChatOptions = {
+  signal?: AbortSignal;
+  stream?: boolean;
+};
+
+export async function sendDocChatMessage(
+  sessionId: string,
+  message: string,
+  opts: SendDocChatOptions = {}
+) {
+  const response = await fetch(`${DOCUMENT_CHAT_BASE_PATH}/${sessionId}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    signal: opts.signal,
+    body: JSON.stringify({ message }),
+  });
+
+  if (!response.ok) {
+    throw new Error('Error al enviar mensaje');
+  }
+
+  if (opts.stream && response.body) {
+    return response.body;
+  }
+
+  return (await response.json()) as { content: string };
+}
+

--- a/src/utils/voiceLabels.ts
+++ b/src/utils/voiceLabels.ts
@@ -1,0 +1,55 @@
+export const VOICE_PREF = ["es-gt", "es-mx", "es-us", "es-es"];
+
+export function formatVoiceLabel(v: SpeechSynthesisVoice) {
+  const name = (v.name || v.voiceURI || "").trim();
+  const lang = (v.lang || "").toUpperCase();
+  const region = lang.includes("-") ? lang.split("-")[1] : "";
+  const simple =
+    name
+      .replace(/^Microsoft\s+/i, "")
+      .replace(/\s*-\s*Spanish.*$/i, "")
+      .split(/\s+/)[0] || name;
+  return region ? `${simple} (${region})` : simple;
+}
+
+export function sortVoices(voices: SpeechSynthesisVoice[]) {
+  const score = (v: SpeechSynthesisVoice) => {
+    const l = (v.lang || "").toLowerCase();
+    const idx = VOICE_PREF.findIndex((pref) => l.startsWith(pref));
+    return idx === -1 ? VOICE_PREF.length : idx;
+  };
+
+  return [...voices]
+    .filter((voice) => (voice.lang || "").toLowerCase().startsWith("es"))
+    .sort((a, b) => {
+      const scoreA = score(a);
+      const scoreB = score(b);
+      if (scoreA !== scoreB) {
+        return scoreA - scoreB;
+      }
+      return (a.name || "").localeCompare(b.name || "");
+    });
+}
+
+const STORAGE_KEY = "ttsVoiceURI";
+
+export function loadPreferredVoice(voices: SpeechSynthesisVoice[]) {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return null;
+    return voices.find((voice) => voice.voiceURI === stored || voice.name === stored) || null;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function savePreferredVoice(voice: SpeechSynthesisVoice | null) {
+  try {
+    const identifier = voice ? voice.voiceURI || voice.name || "" : "";
+    if (identifier) {
+      localStorage.setItem(STORAGE_KEY, identifier);
+    }
+  } catch (error) {
+    // no-op
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the document summary dialog with a sticky toolbar, tabs for summary and document chat, and accessible focus handling
- add streaming-friendly summary generation, clipboard/download controls, and reusable TTS voice utilities with persistence
- wire a new in-dialog chat experience backed by the AI chat service endpoints and supporting streaming replies

## Testing
- npm run lint

## QA
1. Open cualquier documento y pulsa "Resumir Documento" para abrir el modal.
2. Usa "Generar Resumen IA" y confirma que el contenido aparece por streaming y que Copiar/Descargar responden.
3. Cambia la voz de TTS, reproduce y pausa; cierra el modal para verificar que se detiene la lectura.
4. Abre la pestaña "Chat del documento", envía un mensaje y valida que la respuesta llega (stream o JSON) sin errores.


------
https://chatgpt.com/codex/tasks/task_e_68dff8458c34833282f69a80b98e27ed