### PR TITLE
Redesign AI document summary dialog with streaming and new TTS

### DIFF
--- a/src/components/ai/SummaryActions.tsx
+++ b/src/components/ai/SummaryActions.tsx
@@ -23,8 +23,17 @@ export function SummaryActions({
   className,
 }: SummaryActionsProps) {
   return (
-    <div className={cn("flex flex-wrap items-center gap-2", className)}>
-      <Button onClick={onGenerate} disabled={isLoading}>
+    <div
+      className={cn(
+        "flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center",
+        className,
+      )}
+    >
+      <Button
+        onClick={onGenerate}
+        disabled={isLoading}
+        className="h-11 rounded-full px-5 text-sm font-medium sm:h-10"
+      >
         {isLoading ? (
           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
         ) : (
@@ -32,24 +41,26 @@ export function SummaryActions({
         )}
         {isLoading ? "Generando…" : "Generar Resumen IA"}
       </Button>
-      <Button
-        variant="outline"
-        onClick={onCopy}
-        disabled={disabled || isLoading}
-        className="min-w-[110px]"
-      >
-        <Copy className="mr-2 h-4 w-4" />
-        Copiar
-      </Button>
-      <Button
-        variant="outline"
-        onClick={onDownload}
-        disabled={disabled || isLoading}
-        className="min-w-[130px]"
-      >
-        <Download className="mr-2 h-4 w-4" />
-        Descargar
-      </Button>
+      <div className="flex flex-1 flex-col gap-2 sm:flex-row sm:flex-initial">
+        <Button
+          variant="outline"
+          onClick={onCopy}
+          disabled={disabled || isLoading}
+          className="h-11 rounded-full px-4 sm:h-10"
+        >
+          <Copy className="mr-2 h-4 w-4" />
+          Copiar
+        </Button>
+        <Button
+          variant="outline"
+          onClick={onDownload}
+          disabled={disabled || isLoading}
+          className="h-11 rounded-full px-4 sm:h-10"
+        >
+          <Download className="mr-2 h-4 w-4" />
+          Descargar
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/services/documentsService.ts
+++ b/src/services/documentsService.ts
@@ -507,10 +507,9 @@ export async function signDocument(payload: {
 export const DOCUMENT_SUMMARY_ANALYZE_PATH = '/api/documents/analyze-pdf'; // TODO: ajustar path si el backend difiere
 const DOCUMENT_CHAT_BASE_PATH = '/api/v1/documents/ai/chat'; // TODO: ajustar path si el backend difiere
 
-export async function startDocChat(cuadroFirmasId: number, init: RequestInit = {}) {
+export async function startDocChat(cuadroFirmasId: number): Promise<{ sessionId: string }> {
   const response = await fetch(`${DOCUMENT_CHAT_BASE_PATH}/start/${cuadroFirmasId}`, {
     method: 'POST',
-    ...init,
   });
 
   if (!response.ok) {
@@ -528,8 +527,8 @@ type SendDocChatOptions = {
 export async function sendDocChatMessage(
   sessionId: string,
   message: string,
-  opts: SendDocChatOptions = {}
-) {
+  opts: SendDocChatOptions = {},
+): Promise<ReadableStream<Uint8Array> | { content: string }> {
   const response = await fetch(`${DOCUMENT_CHAT_BASE_PATH}/${sessionId}`, {
     method: 'POST',
     headers: {

--- a/src/utils/voiceLabels.ts
+++ b/src/utils/voiceLabels.ts
@@ -48,6 +48,8 @@ export function savePreferredVoice(voice: SpeechSynthesisVoice | null) {
     const identifier = voice ? voice.voiceURI || voice.name || "" : "";
     if (identifier) {
       localStorage.setItem(STORAGE_KEY, identifier);
+    } else {
+      localStorage.removeItem(STORAGE_KEY);
     }
   } catch (error) {
     // no-op


### PR DESCRIPTION
## Summary
- redesign the AI document summary dialog to start streaming summaries on open, improve accessibility, and update the responsive toolbar
- refresh the summary action buttons and text-to-speech player with a more visual UI, animated playback state, and voice preference handling
- tighten document AI service helpers and voice preference utilities for the chat and TTS flows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e001047c108332a92678a76e9f0f92