### PR TITLE
Improve document summary dialog layout and TTS

### DIFF
--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -296,8 +296,8 @@ export const DocumentSummaryDialog = forwardRef<
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        className="grid place-items-center p-4 sm:p-6 [&_[data-dialog-content]]:max-h-[90vh] [&_[data-dialog-content]]:w-[min(96vw,560px)] [&_[data-dialog-content]]:gap-4 [&_[data-dialog-content]]:p-4 md:[&_[data-dialog-content]]:w-[min(92vw,900px)] sm:[&_[data-dialog-content]]:gap-5"
-        aria-describedby={undefined}
+        aria-describedby="doc-summary-desc"
+        className="w-full max-w-[94vw] overflow-visible p-4 sm:max-w-[900px] sm:p-6"
         onEscapeKeyDown={() => {
           abortStreaming();
           stopTTS();
@@ -312,7 +312,7 @@ export const DocumentSummaryDialog = forwardRef<
         }}
       >
         <div className="flex max-h-[82vh] flex-col">
-          <DialogHeader className="mb-0 space-y-3 p-0">
+          <DialogHeader className="mb-3 p-0">
             <div className="flex items-start justify-between gap-3">
               <div className="space-y-2">
                 <DialogTitle
@@ -322,30 +322,32 @@ export const DocumentSummaryDialog = forwardRef<
                 >
                   Resumen IA del Documento
                 </DialogTitle>
-                <DialogDescription className="sr-only md:not-sr-only md:text-sm md:text-muted-foreground">
+                <DialogDescription
+                  id="doc-summary-desc"
+                  className="hidden md:block md:text-sm md:text-muted-foreground"
+                >
                   Genera un resumen inteligente y conversa con la IA sobre el documento.
                 </DialogDescription>
               </div>
-              <Badge variant="secondary" className="uppercase">
+              <Badge variant="secondary" className="shrink-0 self-start uppercase">
                 IA
               </Badge>
             </div>
           </DialogHeader>
 
-          <div className="flex flex-col gap-3 sm:gap-4 md:flex-row md:items-start md:justify-between">
+          <div className="flex flex-col gap-3 overflow-visible sm:gap-4">
             <SummaryActions
               disabled={!markdown}
               isLoading={isLoading}
               onGenerate={() => void generateSummary()}
               onCopy={() => void handleCopy()}
               onDownload={handleDownload}
-              className="md:flex-1"
             />
             <SummaryTTSControls
               ref={ttsRef}
               markdown={markdown}
               variant="compact"
-              className="w-full md:max-w-sm"
+              className="w-full overflow-visible"
             />
           </div>
 

--- a/src/components/ai/SummaryActions.tsx
+++ b/src/components/ai/SummaryActions.tsx
@@ -23,47 +23,42 @@ export function SummaryActions({
   className,
 }: SummaryActionsProps) {
   return (
-    <div
-      className={cn(
-        "flex flex-col gap-2 text-sm sm:flex-row sm:items-center",
-        className,
-      )}
-    >
+    <div className={cn("flex w-full flex-wrap items-center gap-2", className)}>
       <Button
         onClick={onGenerate}
         disabled={isLoading}
         size="sm"
-        className="w-full sm:w-auto"
+        className="flex-1 sm:flex-none"
       >
         {isLoading ? (
           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
         ) : (
           <Sparkles className="mr-2 h-4 w-4" />
         )}
-        {isLoading ? "Generando…" : "Generar Resumen IA"}
+        <span className="truncate">
+          {isLoading ? "Generando…" : "Generar Resumen IA"}
+        </span>
       </Button>
-      <div className="flex w-full gap-2 sm:w-auto sm:gap-3">
-        <Button
-          variant="secondary"
-          onClick={onCopy}
-          disabled={disabled || isLoading}
-          size="sm"
-          className="flex-1 sm:flex-none"
-        >
-          <Copy className="mr-2 h-4 w-4" />
-          Copiar
-        </Button>
-        <Button
-          variant="secondary"
-          onClick={onDownload}
-          disabled={disabled || isLoading}
-          size="sm"
-          className="flex-1 sm:flex-none"
-        >
-          <Download className="mr-2 h-4 w-4" />
-          Descargar
-        </Button>
-      </div>
+      <Button
+        variant="secondary"
+        onClick={onCopy}
+        disabled={disabled || isLoading}
+        size="sm"
+        className="px-2"
+      >
+        <Copy className="h-4 w-4" />
+        <span className="sr-only sm:not-sr-only sm:ml-2">Copiar</span>
+      </Button>
+      <Button
+        variant="secondary"
+        onClick={onDownload}
+        disabled={disabled || isLoading}
+        size="sm"
+        className="px-2"
+      >
+        <Download className="h-4 w-4" />
+        <span className="sr-only sm:not-sr-only sm:ml-2">Descargar</span>
+      </Button>
     </div>
   );
 }

--- a/src/utils/voiceLabels.ts
+++ b/src/utils/voiceLabels.ts
@@ -31,13 +31,20 @@ export function sortVoices(voices: SpeechSynthesisVoice[]) {
     });
 }
 
-const STORAGE_KEY = "ttsVoiceURI";
+const STORAGE_KEY = "ttsVoiceId";
+
+const buildVoiceId = (voice: SpeechSynthesisVoice) =>
+  `${voice.name}__${voice.lang}__${String(voice.localService)}__${voice.voiceURI || "no-uri"}`;
 
 export function loadPreferredVoice(voices: SpeechSynthesisVoice[]) {
   try {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (!stored) return null;
-    return voices.find((voice) => voice.voiceURI === stored || voice.name === stored) || null;
+    return (
+      voices.find((voice) => buildVoiceId(voice) === stored) ||
+      voices.find((voice) => voice.voiceURI === stored || voice.name === stored) ||
+      null
+    );
   } catch (error) {
     return null;
   }
@@ -45,7 +52,7 @@ export function loadPreferredVoice(voices: SpeechSynthesisVoice[]) {
 
 export function savePreferredVoice(voice: SpeechSynthesisVoice | null) {
   try {
-    const identifier = voice ? voice.voiceURI || voice.name || "" : "";
+    const identifier = voice ? buildVoiceId(voice) : "";
     if (identifier) {
       localStorage.setItem(STORAGE_KEY, identifier);
     } else {


### PR DESCRIPTION
## Summary
- center the document summary dialog, wire up aria-describedby, and tighten the header/scroll layout for mobile and desktop
- render summary actions on a single responsive row and use the compact TTS controls without clipping
- overhaul voice selection to use stable ids with persistence, popper positioning, and compact icon buttons
- update the voice preference helper to store the new identifiers

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e03e62affc83329921b9dc4599841f