### PR TITLE
Improve AI summary modal layout

### DIFF
--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -321,7 +321,8 @@ export const DocumentSummaryDialog = forwardRef<
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        className="p-0 max-w-4xl h-[90vh] overflow-hidden [&_[data-dialog-content]]:max-h-none [&_[data-dialog-content]]:w-full [&_[data-dialog-content]]:p-0"
+        size="xl"
+        className="p-0 max-w-none h-[90vh] lg:h-auto overflow-hidden [&_[data-dialog-content]]:h-full lg:[&_[data-dialog-content]]:h-auto [&_[data-dialog-content]]:max-h-[min(calc(100vh-96px),900px)] [&_[data-dialog-content]]:max-w-[1100px] [&_[data-dialog-content]]:w-full [&_[data-dialog-content]]:mx-auto [&_[data-dialog-content]]:p-0"
         aria-describedby={undefined}
         onEscapeKeyDown={() => {
           abortStreaming();
@@ -362,54 +363,60 @@ export const DocumentSummaryDialog = forwardRef<
             {/* Panel de acciones principales */}
             <Card className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border-blue-200 dark:border-blue-800">
               <CardContent className="p-4">
-                <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
                   {/* Acciones de resumen */}
-                  <div className="flex flex-col sm:flex-row gap-3 flex-1">
-                    <Button 
-                      onClick={generateSummary} 
-                      disabled={isLoading}
-                      className="h-12 px-6 bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary text-white shadow-lg hover:shadow-xl transition-all duration-200"
-                    >
-                      {isLoading ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Generando...
-                        </>
-                      ) : (
-                        <>
+                  <div className="flex flex-col gap-3 xl:flex-1">
+                    <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3">
+                      <Button
+                        onClick={generateSummary}
+                        disabled={isLoading}
+                        className="h-12 w-full sm:w-auto px-6 bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary text-white shadow-lg hover:shadow-xl transition-all duration-200"
+                      >
+                        {isLoading ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Generando...
+                          </>
+                        ) : (
+                          <>
+                            <Sparkles className="mr-2 h-4 w-4" />
+                            Generar Resumen IA
+                          </>
+                        )}
+                      </Button>
+
+                      <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                        <Button
+                          variant="outline"
+                          onClick={handleCopy}
+                          disabled={!markdown || isLoading}
+                          className="h-12 w-full sm:w-auto px-4 border-2 hover:bg-green-50 hover:text-green-700 hover:border-green-300 transition-colors"
+                        >
                           <Sparkles className="mr-2 h-4 w-4" />
-                          Generar Resumen IA
-                        </>
-                      )}
-                    </Button>
-                    
-                    <div className="flex gap-2">
-                      <Button 
-                        variant="outline" 
-                        onClick={handleCopy} 
-                        disabled={!markdown || isLoading}
-                        className="h-12 px-4 border-2 hover:bg-green-50 hover:text-green-700 hover:border-green-300 transition-colors"
-                      >
-                        <Sparkles className="mr-2 h-4 w-4" /> 
-                        Copiar
-                      </Button>
-                      <Button 
-                        variant="outline" 
-                        onClick={handleDownload} 
-                        disabled={!markdown || isLoading}
-                        className="h-12 px-4 border-2 hover:bg-blue-50 hover:text-blue-700 hover:border-blue-300 transition-colors"
-                      >
-                        <Sparkles className="mr-2 h-4 w-4" /> 
-                        Descargar
-                      </Button>
+                          Copiar
+                        </Button>
+                        <Button
+                          variant="outline"
+                          onClick={handleDownload}
+                          disabled={!markdown || isLoading}
+                          className="h-12 w-full sm:w-auto px-4 border-2 hover:bg-blue-50 hover:text-blue-700 hover:border-blue-300 transition-colors"
+                        >
+                          <Sparkles className="mr-2 h-4 w-4" />
+                          Descargar
+                        </Button>
+                      </div>
                     </div>
+                    <p className="text-sm text-muted-foreground">
+                      Genera, comparte o descarga el resumen con un solo clic.
+                    </p>
                   </div>
 
                   {/* Control de voz */}
                   <SummaryTTSControls
                     ref={ttsRef}
                     markdown={markdown}
-                    className="w-full lg:w-auto"
+                    variant="compact"
+                    className="w-full xl:max-w-sm"
                   />
                 </div>
               </CardContent>

--- a/src/components/ai/SummaryTTSControls.tsx
+++ b/src/components/ai/SummaryTTSControls.tsx
@@ -91,6 +91,28 @@ function splitIntoSegments(text: string) {
   return segments;
 }
 
+function formatVoiceLabel(voice: SpeechSynthesisVoice) {
+  const rawName = voice.name || voice.voiceURI || "";
+  const cleanedName = rawName
+    .replace(/\b(Microsoft|Google|Amazon|Apple|Online|Neural|Natural|Standard|Voice)\b/gi, "")
+    .replace(/\([^)]*\)/g, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+
+  const simplifiedName = cleanedName
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .join(" ");
+
+  const langTag = (voice.lang || "").replace(/_/g, "-").toUpperCase();
+
+  const label = simplifiedName || rawName || langTag || "Voz";
+
+  return langTag ? `${label} (${langTag})` : label;
+}
+
 const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSControlsProps>(
   ({ markdown, className, variant = "default" }, ref) => {
     const { toast } = useToast();
@@ -319,10 +341,24 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
       ? "Selecciona una voz"
       : "Cargando voces…";
 
+    const isCompact = variant === "compact";
+
     return (
-      <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-2 border-purple-200 dark:border-purple-800 shadow-lg">
-        <CardContent className="p-4">
-          <div className="flex flex-col sm:flex-row items-center gap-4">
+      <Card
+        className={cn(
+          "w-full bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-2 border-purple-200 dark:border-purple-800 shadow-lg",
+          className,
+        )}
+      >
+        <CardContent className={cn("p-4", isCompact ? "sm:p-4" : "sm:p-5") }>
+          <div
+            className={cn(
+              "flex w-full flex-col gap-4",
+              isCompact
+                ? "md:flex-row md:items-start md:justify-between xl:items-center"
+                : "sm:flex-row sm:items-center sm:justify-between"
+            )}
+          >
             <div className="flex items-center gap-3 min-w-[200px]">
               <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-900">
                 <Volume2 className="h-5 w-5 text-purple-600 dark:text-purple-400" />
@@ -331,16 +367,21 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
                   ¿Escuchar resumen?
                 </p>
-                <Badge 
-                  variant="secondary" 
+                <Badge
+                  variant="secondary"
                   className="mt-1 bg-purple-100 text-purple-700 border-purple-200 text-xs"
                 >
                   {statusLabel}
                 </Badge>
               </div>
             </div>
-            
-            <div className="flex-1 flex flex-col sm:flex-row items-center gap-3 min-w-0">
+
+            <div
+              className={cn(
+                "flex-1 min-w-0 flex flex-col gap-3",
+                isCompact ? "sm:flex-col lg:flex-row lg:items-center" : "sm:flex-row sm:items-center"
+              )}
+            >
               <Select
                 value={voiceIdentifier || undefined}
                 onValueChange={(value) => {
@@ -351,10 +392,10 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 }}
                 disabled={!voices.length || !isSupported}
               >
-                <SelectTrigger className="h-10 min-w-[200px] border-2 border-purple-200 bg-white px-3 text-sm font-medium text-purple-900 shadow-sm transition-colors hover:border-purple-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 dark:bg-gray-800 dark:text-purple-100 dark:border-purple-700">
+                <SelectTrigger className="h-10 w-full min-w-0 border-2 border-purple-200 bg-white px-3 text-sm font-medium text-purple-900 shadow-sm transition-colors hover:border-purple-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 dark:bg-gray-800 dark:text-purple-100 dark:border-purple-700">
                   <SelectValue placeholder={voicePlaceholder} />
                 </SelectTrigger>
-                <SelectContent 
+                <SelectContent
                   position="popper"
                   sideOffset={8}
                   className="z-[100] max-h-[300px] w-[var(--radix-select-trigger-width)]"
@@ -362,22 +403,27 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 >
                   {voices.map((voice) => {
                     const id = voice.voiceURI || voice.name;
-                    const label = voice.name || voice.voiceURI;
-                    const langInfo = voice.lang ? ` (${voice.lang})` : '';
+                    const label = formatVoiceLabel(voice);
                     return (
                       <SelectItem key={id} value={id} className="text-sm">
-                        🗣️ {label}{langInfo}
+                        🗣️ {label}
                       </SelectItem>
                     );
                   })}
                 </SelectContent>
               </Select>
 
-              <div className="flex gap-2">
+              <div
+                className={cn(
+                  "flex gap-2",
+                  isCompact ? "justify-start" : "justify-center sm:justify-end",
+                  "w-full sm:w-auto"
+                )}
+              >
                 {showPlayButton && (
-                  <Button 
-                    variant="ghost" 
-                    size="icon" 
+                  <Button
+                    variant="ghost"
+                    size="icon"
                     className={`h-10 w-10 rounded-full transition-all ${
                       status === "idle" 
                         ? "bg-green-500 hover:bg-green-600 text-white shadow-lg" 


### PR DESCRIPTION
## Summary
- center the AI summary dialog on large screens with a wider, responsive container
- reorganize the action buttons for better spacing and add supporting helper text
- compact the TTS controls and shorten voice labels for improved readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0466a16b4833287bf5133d553dd33