### PR TITLE
Refine AI summary dialog layout on mobile and desktop

### DIFF
--- a/src/components/ai/DocChatPanel.tsx
+++ b/src/components/ai/DocChatPanel.tsx
@@ -229,32 +229,45 @@ export function DocChatPanel({
 
   return (
     <div className="flex h-full flex-col">
+      <div className="border-b border-muted-200/70 bg-muted/30 px-4 py-3 dark:border-muted-800/70 dark:bg-muted/10">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Bot className="h-4 w-4" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-foreground">Chat del documento</p>
+            <p className="text-xs text-muted-foreground">
+              Conversa con la IA sobre secciones específicas del archivo.
+            </p>
+          </div>
+        </div>
+      </div>
       <div className="flex-1 overflow-hidden">
         <ScrollArea ref={scrollAreaRef} className="h-full pr-4">
           <div className="flex flex-col gap-4 p-4 text-sm">
             {messages.length === 0 ? (
-              <p className="text-muted-foreground">
+              <div className="rounded-xl border border-dashed border-muted-200 bg-muted/20 px-4 py-6 text-center text-muted-foreground dark:border-muted-800 dark:bg-muted/10">
                 Inicia una conversación para consultar detalles del documento.
-              </p>
+              </div>
             ) : (
               messages.map((message) => (
                 <div
                   key={message.id}
                   className={cn(
-                    "flex gap-3", 
+                    "flex gap-3",
                     message.role === "user" ? "justify-end" : "justify-start",
                   )}
                 >
                   {message.role === "assistant" && (
-                    <div className="mt-1 flex h-6 w-6 items-center justify-center rounded-full bg-muted">
+                    <div className="mt-1 flex h-7 w-7 items-center justify-center rounded-full bg-primary/10 text-primary">
                       <Bot className="h-4 w-4" />
                     </div>
                   )}
                   <div
                     className={cn(
-                      "max-w-full rounded-lg px-3 py-2", 
+                      "max-w-[85%] rounded-2xl px-4 py-3 shadow-sm",
                       message.role === "assistant"
-                        ? "bg-muted text-left"
+                        ? "bg-background border border-muted-200 text-left dark:border-muted-800"
                         : "bg-primary text-primary-foreground",
                     )}
                   >
@@ -263,10 +276,10 @@ export function DocChatPanel({
                         {message.content || (message.isStreaming ? "IA está escribiendo…" : "")}
                       </ReactMarkdown>
                     ) : (
-                      <p>{message.content}</p>
+                      <p className="font-medium">{message.content}</p>
                     )}
                     {message.isStreaming && message.role === "assistant" && (
-                      <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                      <div className="mt-2 flex items-center gap-1 text-xs text-muted-foreground">
                         <Loader2 className="h-3 w-3 animate-spin" />
                         <span>IA está escribiendo…</span>
                       </div>
@@ -280,7 +293,7 @@ export function DocChatPanel({
       </div>
       <form
         onSubmit={handleSubmit}
-        className="space-y-3 border-t bg-background/95 p-4"
+        className="space-y-3 border-t border-muted-200/70 bg-background/95 p-4 backdrop-blur-sm dark:border-muted-800/70"
       >
         <Textarea
           ref={textareaRef}
@@ -297,16 +310,21 @@ export function DocChatPanel({
           }}
           rows={3}
           placeholder={placeholder}
+          className="resize-none border border-muted-200/80 shadow-sm focus-visible:ring-2 focus-visible:ring-primary/40 dark:border-muted-800"
         />
         <div className="flex flex-wrap items-center justify-between gap-3">
           <span className="text-xs text-muted-foreground">
             {input.length}/{MAX_INPUT_CHARS}
           </span>
-          <Button type="submit" disabled={!input.trim() || isSending}>
+          <Button
+            type="submit"
+            disabled={!input.trim() || isSending}
+            className="gap-2 bg-primary hover:bg-primary/90"
+          >
             {isSending ? (
-              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              <Loader2 className="h-4 w-4 animate-spin" />
             ) : (
-              <Send className="mr-2 h-4 w-4" />
+              <Send className="h-4 w-4" />
             )}
             {isSending ? "IA está escribiendo…" : "Enviar"}
           </Button>

--- a/src/components/ai/DocumentSummaryDialog.tsx
+++ b/src/components/ai/DocumentSummaryDialog.tsx
@@ -274,7 +274,7 @@ export const DocumentSummaryDialog = forwardRef<
   const summaryContent = useMemo(() => {
     if (markdown) {
       return (
-        <ReactMarkdown className="prose prose-lg max-w-none text-foreground leading-relaxed dark:prose-invert 
+        <ReactMarkdown className="prose prose-base sm:prose-lg max-w-none text-foreground leading-relaxed dark:prose-invert
                                 prose-headings:font-semibold prose-headings:text-primary
                                 prose-p:text-gray-700 dark:prose-p:text-gray-300 prose-p:leading-7
                                 prose-strong:font-bold prose-strong:text-primary
@@ -321,7 +321,8 @@ export const DocumentSummaryDialog = forwardRef<
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogContent
-        className="p-0 max-w-4xl h-[90vh] overflow-hidden [&_[data-dialog-content]]:max-h-none [&_[data-dialog-content]]:w-full [&_[data-dialog-content]]:p-0"
+        size="xl"
+        className="p-0 max-w-none h-[92vh] sm:h-auto overflow-hidden [&_[data-dialog-content]]:h-full sm:[&_[data-dialog-content]]:h-auto [&_[data-dialog-content]]:max-h-[min(calc(100vh-48px),900px)] [&_[data-dialog-content]]:max-w-[1100px] [&_[data-dialog-content]]:w-full [&_[data-dialog-content]]:mx-auto [&_[data-dialog-content]]:p-0"
         aria-describedby={undefined}
         onEscapeKeyDown={() => {
           abortStreaming();
@@ -336,9 +337,9 @@ export const DocumentSummaryDialog = forwardRef<
           titleRef.current?.focus();
         }}
       >
-        <div className="flex flex-col h-full bg-gradient-to-br from-background to-muted/20">
+        <div className="flex flex-col h-full bg-gradient-to-br from-background to-muted/10">
           {/* Header mejorado */}
-          <DialogHeader className="px-6 pt-6 pb-4 border-b bg-gradient-to-r from-primary/5 to-primary/10">
+          <DialogHeader className="px-4 pt-6 pb-4 sm:px-6 border-b bg-gradient-to-r from-primary/5 to-primary/10">
             <div className="flex items-center gap-3">
               <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
                 <Bot className="h-6 w-6 text-primary" />
@@ -358,58 +359,64 @@ export const DocumentSummaryDialog = forwardRef<
             </div>
           </DialogHeader>
 
-          <div className="flex-1 flex flex-col p-6 gap-4 overflow-hidden">
+          <div className="flex-1 flex flex-col p-4 sm:p-6 gap-4 overflow-hidden">
             {/* Panel de acciones principales */}
-            <Card className="bg-gradient-to-r from-blue-50 to-indigo-50 dark:from-blue-950/30 dark:to-indigo-950/30 border-blue-200 dark:border-blue-800">
-              <CardContent className="p-4">
-                <div className="flex flex-col lg:flex-row gap-4 items-start lg:items-center justify-between">
+            <Card className="border border-blue-200/70 dark:border-blue-800/70 shadow-sm backdrop-blur-sm bg-white/80 dark:bg-slate-950/70">
+              <CardContent className="p-4 sm:p-5">
+                <div className="flex flex-col gap-4 2xl:flex-row 2xl:items-start 2xl:justify-between">
                   {/* Acciones de resumen */}
-                  <div className="flex flex-col sm:flex-row gap-3 flex-1">
-                    <Button 
-                      onClick={generateSummary} 
-                      disabled={isLoading}
-                      className="h-12 px-6 bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary text-white shadow-lg hover:shadow-xl transition-all duration-200"
-                    >
-                      {isLoading ? (
-                        <>
-                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Generando...
-                        </>
-                      ) : (
-                        <>
+                  <div className="flex flex-col gap-3 xl:flex-1">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+                      <Button
+                        onClick={generateSummary}
+                        disabled={isLoading}
+                        className="h-11 w-full sm:w-auto px-5 bg-gradient-to-r from-primary to-primary/90 hover:from-primary/95 hover:to-primary text-white shadow-md hover:shadow-lg transition-all duration-200"
+                      >
+                        {isLoading ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Generando...
+                          </>
+                        ) : (
+                          <>
+                            <Sparkles className="mr-2 h-4 w-4" />
+                            Generar Resumen IA
+                          </>
+                        )}
+                      </Button>
+
+                      <div className="grid w-full grid-cols-2 gap-2 sm:flex sm:w-auto sm:flex-row">
+                        <Button
+                          variant="outline"
+                          onClick={handleCopy}
+                          disabled={!markdown || isLoading}
+                          className="h-11 w-full sm:w-auto px-4 border-2 hover:bg-green-50 hover:text-green-700 hover:border-green-300 transition-colors"
+                        >
                           <Sparkles className="mr-2 h-4 w-4" />
-                          Generar Resumen IA
-                        </>
-                      )}
-                    </Button>
-                    
-                    <div className="flex gap-2">
-                      <Button 
-                        variant="outline" 
-                        onClick={handleCopy} 
-                        disabled={!markdown || isLoading}
-                        className="h-12 px-4 border-2 hover:bg-green-50 hover:text-green-700 hover:border-green-300 transition-colors"
-                      >
-                        <Sparkles className="mr-2 h-4 w-4" /> 
-                        Copiar
-                      </Button>
-                      <Button 
-                        variant="outline" 
-                        onClick={handleDownload} 
-                        disabled={!markdown || isLoading}
-                        className="h-12 px-4 border-2 hover:bg-blue-50 hover:text-blue-700 hover:border-blue-300 transition-colors"
-                      >
-                        <Sparkles className="mr-2 h-4 w-4" /> 
-                        Descargar
-                      </Button>
+                          Copiar
+                        </Button>
+                        <Button
+                          variant="outline"
+                          onClick={handleDownload}
+                          disabled={!markdown || isLoading}
+                          className="h-11 w-full sm:w-auto px-4 border-2 hover:bg-blue-50 hover:text-blue-700 hover:border-blue-300 transition-colors"
+                        >
+                          <Sparkles className="mr-2 h-4 w-4" />
+                          Descargar
+                        </Button>
+                      </div>
                     </div>
+                    <p className="text-xs sm:text-sm text-muted-foreground">
+                      Genera, comparte o descarga el resumen con un solo clic.
+                    </p>
                   </div>
 
                   {/* Control de voz */}
                   <SummaryTTSControls
                     ref={ttsRef}
                     markdown={markdown}
-                    className="w-full lg:w-auto"
+                    variant="compact"
+                    className="w-full 2xl:max-w-sm"
                   />
                 </div>
               </CardContent>
@@ -421,9 +428,9 @@ export const DocumentSummaryDialog = forwardRef<
               onValueChange={setActiveTab}
               className="flex-1 flex flex-col overflow-hidden"
             >
-              <TabsList className="grid h-11 w-full grid-cols-2 text-sm bg-muted/50 p-1 rounded-lg">
-                <TabsTrigger 
-                  value="summary" 
+              <TabsList className="grid h-10 w-full grid-cols-2 text-sm bg-muted/40 p-1 rounded-lg">
+                <TabsTrigger
+                  value="summary"
                   className="h-9 text-sm font-medium data-[state=active]:bg-background data-[state=active]:shadow-sm"
                 >
                   <FileText className="h-4 w-4 mr-2" />
@@ -439,8 +446,8 @@ export const DocumentSummaryDialog = forwardRef<
               </TabsList>
 
               <TabsContent value="summary" className="flex-1 overflow-hidden mt-4">
-                <Card className="h-full border-2 shadow-sm bg-gradient-to-b from-white to-gray-50/50 dark:from-gray-900 dark:to-gray-800/50">
-                  <CardContent className="h-full p-6 overflow-auto">
+                <Card className="h-full border border-muted-200/80 dark:border-muted-800/80 shadow-sm bg-card/90">
+                  <CardContent className="h-full p-4 sm:p-6 overflow-auto">
                     <div className="space-y-4">
                       {error && (
                         <Alert variant="destructive" className="mb-4">
@@ -455,7 +462,7 @@ export const DocumentSummaryDialog = forwardRef<
               </TabsContent>
 
               <TabsContent value="chat" className="flex-1 overflow-hidden mt-4">
-                <Card className="h-full border-2 shadow-sm">
+                <Card className="h-full border border-muted-200/80 dark:border-muted-800/80 shadow-sm bg-card/90">
                   <CardContent className="h-full p-0">
                     <DocChatPanel
                       cuadroFirmasId={cuadroFirmasId}

--- a/src/components/ai/SummaryTTSControls.tsx
+++ b/src/components/ai/SummaryTTSControls.tsx
@@ -91,6 +91,28 @@ function splitIntoSegments(text: string) {
   return segments;
 }
 
+function formatVoiceLabel(voice: SpeechSynthesisVoice) {
+  const rawName = voice.name || voice.voiceURI || "";
+  const cleanedName = rawName
+    .replace(/\b(Microsoft|Google|Amazon|Apple|Online|Neural|Natural|Standard|Voice)\b/gi, "")
+    .replace(/\([^)]*\)/g, "")
+    .replace(/[-_]+/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+
+  const simplifiedName = cleanedName
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .join(" ");
+
+  const langTag = (voice.lang || "").replace(/_/g, "-").toUpperCase();
+
+  const label = simplifiedName || rawName || langTag || "Voz";
+
+  return langTag ? `${label} (${langTag})` : label;
+}
+
 const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSControlsProps>(
   ({ markdown, className, variant = "default" }, ref) => {
     const { toast } = useToast();
@@ -319,28 +341,47 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
       ? "Selecciona una voz"
       : "Cargando voces…";
 
+    const isCompact = variant === "compact";
+
     return (
-      <Card className="bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-2 border-purple-200 dark:border-purple-800 shadow-lg">
-        <CardContent className="p-4">
-          <div className="flex flex-col sm:flex-row items-center gap-4">
+      <Card
+        className={cn(
+          "w-full bg-white/70 dark:bg-gray-900/60 backdrop-blur-sm border border-purple-200/70 dark:border-purple-800/60 shadow-sm",
+          className,
+        )}
+      >
+        <CardContent className={cn("p-4", isCompact ? "sm:p-4" : "sm:p-5") }>
+          <div
+            className={cn(
+              "flex w-full flex-col gap-4",
+              isCompact
+                ? "md:flex-row md:items-start md:justify-between xl:items-center"
+                : "sm:flex-row sm:items-center sm:justify-between"
+            )}
+          >
             <div className="flex items-center gap-3 min-w-[200px]">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-900">
-                <Volume2 className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-purple-100/80 dark:bg-purple-900/70">
+                <Volume2 className="h-5 w-5 text-purple-600 dark:text-purple-300" />
               </div>
               <div>
-                <p className="text-sm font-medium text-purple-700 dark:text-purple-300">
+                <p className="text-sm font-semibold text-purple-700 dark:text-purple-200">
                   ¿Escuchar resumen?
                 </p>
-                <Badge 
-                  variant="secondary" 
-                  className="mt-1 bg-purple-100 text-purple-700 border-purple-200 text-xs"
+                <Badge
+                  variant="secondary"
+                  className="mt-1 bg-purple-100/80 text-purple-700 border-purple-200 text-xs"
                 >
                   {statusLabel}
                 </Badge>
               </div>
             </div>
-            
-            <div className="flex-1 flex flex-col sm:flex-row items-center gap-3 min-w-0">
+
+            <div
+              className={cn(
+                "flex-1 min-w-0 flex flex-col gap-3",
+                isCompact ? "sm:flex-col lg:flex-row lg:items-center" : "sm:flex-row sm:items-center"
+              )}
+            >
               <Select
                 value={voiceIdentifier || undefined}
                 onValueChange={(value) => {
@@ -351,10 +392,10 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 }}
                 disabled={!voices.length || !isSupported}
               >
-                <SelectTrigger className="h-10 min-w-[200px] border-2 border-purple-200 bg-white px-3 text-sm font-medium text-purple-900 shadow-sm transition-colors hover:border-purple-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 dark:bg-gray-800 dark:text-purple-100 dark:border-purple-700">
+                <SelectTrigger className="h-10 w-full min-w-0 border border-purple-200 bg-white px-3 text-sm font-medium text-purple-900 shadow-sm transition-colors hover:border-purple-300 focus:border-purple-500 focus:ring-2 focus:ring-purple-200 dark:bg-gray-800 dark:text-purple-100 dark:border-purple-700">
                   <SelectValue placeholder={voicePlaceholder} />
                 </SelectTrigger>
-                <SelectContent 
+                <SelectContent
                   position="popper"
                   sideOffset={8}
                   className="z-[100] max-h-[300px] w-[var(--radix-select-trigger-width)]"
@@ -362,28 +403,29 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 >
                   {voices.map((voice) => {
                     const id = voice.voiceURI || voice.name;
-                    const label = voice.name || voice.voiceURI;
-                    const langInfo = voice.lang ? ` (${voice.lang})` : '';
+                    const label = formatVoiceLabel(voice);
                     return (
                       <SelectItem key={id} value={id} className="text-sm">
-                        🗣️ {label}{langInfo}
+                        🗣️ {label}
                       </SelectItem>
                     );
                   })}
                 </SelectContent>
               </Select>
 
-              <div className="flex gap-2">
+              <div
+                className={cn(
+                  "flex gap-2",
+                  isCompact ? "justify-start" : "justify-center sm:justify-end",
+                  "w-full sm:w-auto"
+                )}
+              >
                 {showPlayButton && (
-                  <Button 
-                    variant="ghost" 
-                    size="icon" 
-                    className={`h-10 w-10 rounded-full transition-all ${
-                      status === "idle" 
-                        ? "bg-green-500 hover:bg-green-600 text-white shadow-lg" 
-                        : "bg-green-500 hover:bg-green-600 text-white shadow-lg"
-                    }`}
-                    onClick={status === "paused" ? handleResume : handlePlay} 
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-10 w-10 rounded-full transition-all bg-emerald-500 hover:bg-emerald-600 text-white shadow-md"
+                    onClick={status === "paused" ? handleResume : handlePlay}
                     disabled={!canStartPlayback}
                     aria-label={status === "paused" ? "Reanudar lectura" : "Reproducir resumen"}
                   >
@@ -393,10 +435,10 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 
                 {showPauseButton && (
                   <Button 
-                    variant="ghost" 
-                    size="icon" 
-                    className="h-10 w-10 rounded-full bg-yellow-500 hover:bg-yellow-600 text-white shadow-lg transition-all"
-                    onClick={handlePause} 
+                    variant="ghost"
+                    size="icon"
+                    className="h-10 w-10 rounded-full bg-amber-500 hover:bg-amber-600 text-white shadow-md transition-all"
+                    onClick={handlePause}
                     aria-label="Pausar lectura"
                   >
                     <Pause className="h-4 w-4" />
@@ -405,10 +447,10 @@ const SummaryTTSControls = forwardRef<SummaryTTSControlsHandle, SummaryTTSContro
                 
                 {showStopButton && (
                   <Button 
-                    variant="ghost" 
-                    size="icon" 
-                    className="h-10 w-10 rounded-full bg-red-500 hover:bg-red-600 text-white shadow-lg transition-all"
-                    onClick={handleStop} 
+                    variant="ghost"
+                    size="icon"
+                    className="h-10 w-10 rounded-full bg-rose-500 hover:bg-rose-600 text-white shadow-md transition-all"
+                    onClick={handleStop}
                     aria-label="Detener lectura"
                   >
                     <Square className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- keep the AI summary dialog centered while reducing padding and card weight for a lighter layout across breakpoints
- place copy and download actions on a single row on mobile, tighten button sizing, and polish the TTS controls for a cleaner presentation
- refresh the document chat panel with a header, refined bubbles, and improved input styling for a more professional feel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0466a16b4833287bf5133d553dd33